### PR TITLE
fix: mock nft and currency deploy script

### DIFF
--- a/bin/deploy-mocks
+++ b/bin/deploy-mocks
@@ -21,8 +21,8 @@ test -z "$TKN_VERSION" && TKN_VERSION="a"
 test -z "$TKN_CHAINID" && TKN_CHAINID=1
 
 # Deploy NFT & Collateral
-NFT_COLLATERAL=$(dapp create test/SimpleNFT)
-CURRENCY=$(seth send --create out/test/SimpleToken.bin 'SimpleToken(string memory,string memory,string memory, uint)' "$TKN_SYMBOL" "$TKN_NAME" "$TKN_VERSION" $(seth --to-uint256 $TKN_CHAINID))
+NFT_COLLATERAL=$(dapp create SimpleNFT)
+CURRENCY=$(seth send --create out/SimpleToken.bin 'SimpleToken(string memory,string memory,string memory, uint)' "$TKN_SYMBOL" "$TKN_NAME" "$TKN_VERSION" $(seth --to-uint256 $TKN_CHAINID))
 
 source $BIN_DIR/lib/load-addresses
 touch "$ADDRESS_DIR/addresses-$(seth chain).json"


### PR DESCRIPTION
sub-folder in `out` are removed in latest dapp version