### PR TITLE
fix: fee debt update after repay

### DIFF
--- a/src/pile.sol
+++ b/src/pile.sol
@@ -190,8 +190,6 @@ contract Pile is DSNote {
         return int(Balance) - int(tkn.balanceOf(address(this))); // safemath
     }
 
-
-
     // borrow() creates a debt by the borrower for the specified amount. 
     function borrow(uint loan, uint wad) public auth note {
         uint fee = loans[loan].fee;
@@ -230,7 +228,10 @@ contract Pile is DSNote {
 
         tkn.transferFrom(usr, address(this), wad);
         loans[loan].debt = sub(loans[loan].debt, wad);
-        Debt -= wad;
+
+        uint fee = loans[loan].fee;
+        fees[fee].debt = sub(fees[fee].debt, wad);
+        Debt = sub(Debt, wad);
 
         tkn.approve(lender,wad);
     }

--- a/src/test/pile.t.sol
+++ b/src/test/pile.t.sol
@@ -75,12 +75,20 @@ contract PileTest is DSTest {
     }
 
     function repay(uint loan, uint wad) public {
+        // pre state
+        (,,uint fee,) = pile.loans(loan);
         uint totalDebt = pile.Debt();
+        (uint totalFeeDebt,,,) = pile.fees(fee);
 
         pile.repay(loan, wad, address(this));
 
+        // post state
         (uint debt,uint balance, ,) = pile.loans(loan);
+        (uint feeDebt,,,) = pile.fees(fee);
+
         assertEq(totalDebt-wad, pile.Debt());
+        assertEq(totalFeeDebt-wad,feeDebt);
+
         assertEq(debt,0);
         assertEq(balance,0);
 


### PR DESCRIPTION
fixes the global `Debt` variable update. 

After a loan has been repaid the `fees[fee].debt` hasn't been updated.

The global `Debt` updated happens based on `fees[fee].debt` and caused the problem.

