### PR TITLE
added require for appraisal and principal in whitelist

### DIFF
--- a/src/appraiser.sol
+++ b/src/appraiser.sol
@@ -33,6 +33,7 @@ contract Appraiser {
 
     // --- Appraiser ---
     function file (uint loan, uint wad) public auth {
+        require(wad > 0);
         value[loan] = wad;
     }
 

--- a/src/shelf.sol
+++ b/src/shelf.sol
@@ -73,6 +73,7 @@ contract Shelf {
     }
     
     function file(uint loan, address registry_, uint nft_, uint principal_) public auth {
+        require(principal_ > 0);
         shelf[loan].registry = registry_;
         shelf[loan].tokenId = nft_;
         shelf[loan].principal = principal_;


### PR DESCRIPTION
it was possible to whitelist a loan with a zero appraisal value.
Which results in a loan which could never be borrowed.

The contracts should not allow whitelisting such a loan at all.