### PR TITLE
feat: wards for deployer contract

### DIFF
--- a/src/deployer.sol
+++ b/src/deployer.sol
@@ -231,17 +231,8 @@ contract Deployer {
 
     }
 
-    function resign() internal {
-        address self = address(this);
-        pile.deny(self);
-        desk.deny(self);
-        shelf.deny(self);
-        admit.deny(self);
-        collateral.deny(self);
-        valve.deny(self);
-        title.deny(self);
-        admin.deny(self);
-        lightswitch.deny(self);
+    function resign() public auth {
+        selfdestruct(msg.sender);
     }
 
     function deployLender(address currency_, address lenderfab_) public auth returns(address) {
@@ -255,9 +246,6 @@ contract Deployer {
         desk.approve(lender_, uint(-1));
         pile.file("lender", lender_);
         desk.file("lender", lender_);
-
-        // remove power of deployer
-        resign();
 
         return lender_;
     }

--- a/src/deployer.sol
+++ b/src/deployer.sol
@@ -30,7 +30,6 @@ contract LenderFabLike {
     function deploy(address,address,address) public returns (address);
 }
 
-
 contract LenderLike {
     function rely(address) public;
     function file(address) public;
@@ -229,6 +228,18 @@ contract Deployer {
         shelf.rely(reception_);
         pile.rely(reception_);
         desk.rely(reception_);
+
+    }
+
+    function resign() internal {
+        address self = address(this);
+        pile.deny(self);
+        desk.deny(self);
+        shelf.deny(self);
+        admit.deny(self);
+        collateral.deny(self);
+        valve.deny(self);
+        title.deny(self);
     }
 
     function deployLender(address currency_, address lenderfab_) public auth returns(address) {
@@ -242,6 +253,10 @@ contract Deployer {
         desk.approve(lender_, uint(-1));
         pile.file("lender", lender_);
         desk.file("lender", lender_);
+
+        // remove power of deployer
+        resign();
+
         return lender_;
     }
 

--- a/src/deployer.sol
+++ b/src/deployer.sol
@@ -240,6 +240,8 @@ contract Deployer {
         collateral.deny(self);
         valve.deny(self);
         title.deny(self);
+        admin.deny(self);
+        lightswitch.deny(self);
     }
 
     function deployLender(address currency_, address lenderfab_) public auth returns(address) {

--- a/src/reception.sol
+++ b/src/reception.sol
@@ -50,7 +50,7 @@ contract Reception is TitleOwned {
     ShelfLike shelf;
     PileLike pile;
 
-    constructor (address desk_, address title_, address shelf_, address pile_) TitleOwned(title_) public {
+        constructor (address desk_, address title_, address shelf_, address pile_) TitleOwned(title_) public {
         wards[msg.sender] = 1;
         desk = DeskLike(desk_);
         shelf = ShelfLike(shelf_);

--- a/src/test/deployer.t.sol
+++ b/src/test/deployer.t.sol
@@ -90,8 +90,9 @@ contract DeployerTest is DSTest {
         admitfab = new AdmitFab();
         adminfab = new AdminFab();
    }
-    
-    function testDeploy() public logs_gas {
+
+
+    function deploy() public returns(address)  {
         Deployer deployer = new Deployer(address(0), titlefab, lightswitchfab, pilefab, shelffab, collateralfab, deskfab,admitfab, adminfab);
 
         appraiser.rely(address(deployer));
@@ -107,5 +108,17 @@ contract DeployerTest is DSTest {
         deployer.deployAdmin(address(appraiser));
         deployer.deploy();
         deployer.deployLender(address(dai), address(lenderfab));
+        return address(deployer);
     }
+
+    function testDeploy() public logs_gas {
+        deploy();
+    }
+
+    function testFailDeploy() public logs_gas {
+        Deployer deployer = Deployer(deploy());
+        deployer.deployValve();
+    }
+
+
 }

--- a/src/test/deployer.t.sol
+++ b/src/test/deployer.t.sol
@@ -93,7 +93,7 @@ contract DeployerTest is DSTest {
 
 
     function deploy() public returns(address)  {
-        Deployer deployer = new Deployer(address(0), titlefab, lightswitchfab, pilefab, shelffab, collateralfab, deskfab,admitfab, adminfab);
+        Deployer deployer = new Deployer(address(123), titlefab, lightswitchfab, pilefab, shelffab, collateralfab, deskfab,admitfab, adminfab);
 
         appraiser.rely(address(deployer));
 
@@ -117,8 +117,10 @@ contract DeployerTest is DSTest {
 
     function testFailDeploy() public logs_gas {
         Deployer deployer = Deployer(deploy());
-        deployer.deployValve();
+        assertEq(deployer.god(), address(123));
+        deployer.resign();
+        // should fail
+        assertEq(deployer.god(), address(123));
     }
-
 
 }


### PR DESCRIPTION
Instead of removing the deployer as a ward from all contracts after the deployment.
Only permissioned addresses are allowed to call the deployer.