### PR TITLE
feat: added version to reception contract

### DIFF
--- a/src/reception.sol
+++ b/src/reception.sol
@@ -45,16 +45,22 @@ contract Reception is TitleOwned {
     modifier auth { require(wards[msg.sender] == 1); _; }
 
     // --- Data ---
-
     DeskLike desk;
     ShelfLike shelf;
     PileLike pile;
+
+    bytes32 public version;
 
     constructor (address desk_, address title_, address shelf_, address pile_) TitleOwned(title_) public {
         wards[msg.sender] = 1;
         desk = DeskLike(desk_);
         shelf = ShelfLike(shelf_);
         pile = PileLike(pile_);
+    }
+
+    function file(bytes32 what, bytes32 data) public auth {
+        if (what == "version") version = data;
+        else revert();
     }
 
     // --- Reception ---

--- a/src/test/reception.t.sol
+++ b/src/test/reception.t.sol
@@ -123,6 +123,18 @@ contract ReceptionTest is DSTest {
         repay(loan, principal);
     }
 
+    function testFileVersion() public {
+        bytes32 version = keccak256("1");
+        reception.file("version",version);
+        assertEq(version, reception.version());
+    }
+
+    function testFailFileVersion() public {
+        bytes32 version = keccak256("1");
+        reception.file("wrong",version);
+        assertEq(version, reception.version());
+    }
+
     function testClose() public {
         uint loan = 1;
         uint principal = 500;


### PR DESCRIPTION
the idea to have a byte32 field for the version in place.

In the future, it might be a hash to receive additional information about the Tinlake deployment from IPFS.

For now we are using it in the UI to support different contract versions.