### PR TITLE
File and depend methods

### DIFF
--- a/src/admin.sol
+++ b/src/admin.sol
@@ -57,6 +57,7 @@ contract Admin {
     function depend (bytes32 what, address addr) public auth {
         if (what == "pile") { pile = PileLike(addr); }
         else if (what == "admit") { admit = AdmitLike(addr); }
+        else if (what == "appraiser") { appraiser = AppraiserLike(addr); }
         else revert();
     }
 
@@ -71,11 +72,6 @@ contract Admin {
         pile.file(loan, fee, 0);
         emit Whitelisted(loan);
         return loan;
-    }
-
-    function file(bytes32 what, address addr) public auth {
-        if (what == "appraiser") { appraiser = AppraiserLike(addr); }
-        else revert();
     }
 
     function file(uint fee, uint speed) public auth {

--- a/src/admin.sol
+++ b/src/admin.sol
@@ -54,6 +54,12 @@ contract Admin {
         pile = PileLike(pile_);
     }
 
+    function depend (bytes32 what, address addr) public auth {
+        if (what == "pile") { pile = PileLike(addr); }
+        else if (what == "admit") { admit = AdmitLike(addr); }
+        else revert();
+    }
+
     // -- Whitelist --
     function whitelist(address registry, uint nft, uint principal, uint appraisal, uint fee, address usr) public auth returns(uint) {
         uint loan = admit.admit(registry, nft, principal, usr);
@@ -65,6 +71,11 @@ contract Admin {
         pile.file(loan, fee, 0);
         emit Whitelisted(loan);
         return loan;
+    }
+
+    function file(bytes32 what, address addr) public auth {
+        if (what == "appraiser") { appraiser = AppraiserLike(addr); }
+        else revert();
     }
 
     function file(uint fee, uint speed) public auth {

--- a/src/admit.sol
+++ b/src/admit.sol
@@ -45,6 +45,11 @@ contract Admit {
         title = TitleLike(title_);
         shelf = ShelfLike(shelf_);
     }
+
+    function depend (bytes32 what, address addr) public auth {
+        if (what == "shelf") { shelf = ShelfLike(addr); }
+        else revert();
+    }
     
     // --- Admit ---
     function admit (address registry, uint nft, uint principal, address usr) public auth returns (uint) {

--- a/src/deployer.sol
+++ b/src/deployer.sol
@@ -233,8 +233,8 @@ contract Deployer {
         lender.rely(address(desk));
 
         desk.approve(lender_, uint(-1));
-        pile.file("lender", lender_);
-        desk.file("lender", lender_);
+        pile.depend("lender", lender_);
+        desk.depend("lender", lender_);
         return lender_;
     }
 

--- a/src/desk.sol
+++ b/src/desk.sol
@@ -70,6 +70,13 @@ contract Desk is Switchable {
 
     }
 
+    function depend (bytes32 what, address addr) public auth {
+        if (what == "pile") { pile = PileLike(addr); }
+        else if (what == "valve") { valve = ValveLike(addr); }
+        else if (what == "collateral") { collateral = CollateralLike(addr); }
+        else revert();
+    }
+
     function file(bytes32 what, address data) public auth {
         if (what == "lender") { lender = LenderLike(data); }
     }

--- a/src/desk.sol
+++ b/src/desk.sol
@@ -74,11 +74,8 @@ contract Desk is Switchable {
         if (what == "pile") { pile = PileLike(addr); }
         else if (what == "valve") { valve = ValveLike(addr); }
         else if (what == "collateral") { collateral = CollateralLike(addr); }
+        else if (what == "lender") { lender = LenderLike(addr); }
         else revert();
-    }
-
-    function file(bytes32 what, address data) public auth {
-        if (what == "lender") { lender = LenderLike(data); }
     }
 
     function approve(address usr, uint wad) public auth {

--- a/src/pile.sol
+++ b/src/pile.sol
@@ -66,7 +66,7 @@ contract Pile is DSNote {
 
     }
 
-    function file (bytes32 what, address data) public auth {
+    function depend(bytes32 what, address data) public auth {
         if (what == "lender") { lender = data; }
     }
 

--- a/src/reception.sol
+++ b/src/reception.sol
@@ -78,7 +78,6 @@ contract Reception is TitleOwned {
         // borrow max amount
         uint wad = pile.balanceOf(loan);
         pile.withdraw(loan, wad, deposit);
-
     }
 
     function repay(uint loan, uint wad, address usr) public owner(loan) {

--- a/src/reception.sol
+++ b/src/reception.sol
@@ -65,7 +65,6 @@ contract Reception is TitleOwned {
         else revert();
     }
 
-
     function file(bytes32 what, bytes32 data) public auth {
         if (what == "version") version = data;
         else revert();

--- a/src/reception.sol
+++ b/src/reception.sol
@@ -58,6 +58,14 @@ contract Reception is TitleOwned {
         pile = PileLike(pile_);
     }
 
+    function depend (bytes32 what, address addr) public auth {
+        if (what == "pile") { pile = PileLike(addr); }
+        else if (what == "shelf") { shelf = ShelfLike(addr); }
+        else if (what == "desk") { desk = DeskLike(addr); }
+        else revert();
+    }
+
+
     function file(bytes32 what, bytes32 data) public auth {
         if (what == "version") version = data;
         else revert();

--- a/src/shelf.sol
+++ b/src/shelf.sol
@@ -67,6 +67,17 @@ contract Shelf {
     }
     
     // --- Shelf ---
+
+    function depend (bytes32 what, address addr) public auth {
+        if (what == "pile") { pile = PileLike(addr); }
+        else revert();
+    }
+
+    function file(bytes32 what, address addr) public auth {
+        if (what == "appraiser") { appraiser = AppraiserLike(addr); }
+        else revert();
+    }
+
     function file(uint loan, address registry_, uint nft_) public auth {
         shelf[loan].registry = registry_;
         shelf[loan].tokenId = nft_;

--- a/src/shelf.sol
+++ b/src/shelf.sol
@@ -70,11 +70,7 @@ contract Shelf {
 
     function depend (bytes32 what, address addr) public auth {
         if (what == "pile") { pile = PileLike(addr); }
-        else revert();
-    }
-
-    function file(bytes32 what, address addr) public auth {
-        if (what == "appraiser") { appraiser = AppraiserLike(addr); }
+        else if (what == "appraiser") { appraiser = AppraiserLike(addr); }
         else revert();
     }
 

--- a/src/test/desk.t.sol
+++ b/src/test/desk.t.sol
@@ -30,7 +30,7 @@ contract DeskTest is DSTest {
         lightswitch = new LightSwitchMock();
 
         desk = new Desk(address(pile), address(valve), address(collateral), address(lightswitch));
-        desk.file("lender", address(lender));
+        desk.depend("lender", address(lender));
     }
 
 

--- a/src/valve.sol
+++ b/src/valve.sol
@@ -44,7 +44,12 @@ contract Valve {
         wards[msg.sender] = 1;
         tkn = TokenLike(tkn_); 
         shelf = ShelfLike(shelf_);
-    } 
+    }
+
+    function depend (bytes32 what, address addr) public auth {
+        if (what == "shelf") { shelf = ShelfLike(addr); }
+        else revert();
+    }
 
     // --- Valve ---
     function balance(address usr) public auth {


### PR DESCRIPTION
Closes #72 and #60 .

Sets up a `file` method for external configurations, and introduces `depend` for core contract dependencies.