### PR TITLE
feat: removed loan chi from pile

### DIFF
--- a/src/pile.sol
+++ b/src/pile.sol
@@ -46,14 +46,22 @@ contract Pile is DSNote, TitleOwned {
     }
 
     struct Loan {
-        uint debt;
         uint balance;
         uint fee;
-        uint chi;
+        uint pie;
     }
 
     mapping (uint => Fee) public fees;
-    mapping (uint => Loan) public loans;
+    // TODO can be renamed to loans again after loans func is removed
+    mapping (uint => Loan) public loans_;
+
+    // TODO can be removed after tests don't depend on old loan struct anymore
+    function loans(uint loan) public view returns (uint, uint, uint, uint)  {
+        uint fee = loans_[loan].fee;
+        uint debt = rmul(loans_[loan].pie,fees[fee].chi);
+        return (debt, loans_[loan].balance,loans_[loan].fee, 0);
+    }
+
     uint public Balance;
     uint public Debt;
 
@@ -64,7 +72,6 @@ contract Pile is DSNote, TitleOwned {
         tkn = TokenLike(tkn_);
         fees[0].chi = ONE;
         fees[0].speed = ONE;
-
     }
 
     function depend(bytes32 what, address data) public auth {
@@ -72,8 +79,8 @@ contract Pile is DSNote, TitleOwned {
     }
 
     function file(uint loan, uint fee_, uint balance_) public auth note {
-        loans[loan].fee = fee_;
-        loans[loan].balance = balance_;
+        loans_[loan].fee = fee_;
+        loans_[loan].balance = balance_;
     }
     
     function file(uint fee, uint speed_) public auth note {
@@ -129,13 +136,8 @@ contract Pile is DSNote, TitleOwned {
     function rdiv(uint x, uint y) internal pure returns (uint z) {
         z = add(mul(x, ONE), y / 2) / y;
     }
-
-    function update(uint loan, uint chi) internal view returns (uint) {
-        uint chi_ = ONE;
-        if(loans[loan].chi != 0) {
-            chi_ = rdiv(chi, loans[loan].chi);
-        }
-        return rmul(loans[loan].debt, chi_);
+    function div(uint x, uint y) internal pure returns (uint z) {
+        z = x / y;
     }
 
     function incDebt(uint fee, uint wad) internal {
@@ -150,13 +152,14 @@ contract Pile is DSNote, TitleOwned {
     }
 
     function burden(uint loan) public view returns (uint) {
-        uint fee = loans[loan].fee;
+        uint fee = loans_[loan].fee;
         uint chi = fees[fee].chi;
 
         if (now >= fees[fee].rho) {
             (chi, ,) = compounding(fee);
         }
-        return update(loan, chi);
+        uint debt = rmul(loans_[loan].pie, chi);
+        return debt;
     }
 
     function compounding(uint fee) public view returns (uint,uint,uint) {
@@ -185,31 +188,27 @@ contract Pile is DSNote, TitleOwned {
     }
 
     function collect(uint loan) public {
-        uint fee = loans[loan].fee;
+        uint fee = loans_[loan].fee;
         if (now >= fees[fee].rho) {
             drip(fee);
         }
-        loans[loan].debt = update(loan, fees[fee].chi);
-        loans[loan].chi = fees[fee].chi;
     }
 
     // --- Pile ---
-    // want() is the the additional token that must be supplied for the Pile to cover all outstanding loans. If negative, it's the reserves the Pile has.
+    // want() is the the additional token that must be supplied for the Pile to cover all outstanding loans_. If negative, it's the reserves the Pile has.
     function want() public view returns (int) {
         return int(Balance) - int(tkn.balanceOf(address(this))); // safemath
     }
 
     function initLoan(uint loan,uint wad, uint chi) internal {
-        loans[loan].chi = chi;
-        loans[loan].debt = add(loans[loan].debt, wad);
-        loans[loan].balance = add(loans[loan].balance, wad);
+        loans_[loan].pie  = rdiv(wad, chi);
+        loans_[loan].balance = add(loans_[loan].balance, wad);
         Balance = add(Balance, wad);
-
     }
 
     // borrow() creates a debt by the borrower for the specified amount. 
     function borrow(uint loan, uint wad) public auth note {
-        uint fee = loans[loan].fee;
+        uint fee = loans_[loan].fee;
         drip(fee);
 
         initLoan(loan, wad,fees[fee].chi);
@@ -219,34 +218,45 @@ contract Pile is DSNote, TitleOwned {
 
     // withdraw() moves token from the Pile to the user
     function withdraw(uint loan, uint wad, address usr) public owner(loan) note {
-        require(wad <= loans[loan].balance, "only max. balance can be withdrawn");
-        loans[loan].balance -= wad;
+        require(wad <= loans_[loan].balance, "only max. balance can be withdrawn");
+        loans_[loan].balance -= wad;
         Balance -= wad;
         tkn.transferFrom(address(this), usr, wad);
     }
 
     function balanceOf(uint loan) public view returns (uint) {
-        return loans[loan].balance;
+        return loans_[loan].balance;
     }
 
     // repay() a certain amount of token from the user to the Pile
     function repay(uint loan, uint wad) public owner(loan) note {
         // moves currency from usr to pile and reduces debt
-        require(loans[loan].balance == 0,"before repay loan needs to be withdrawn");
+        require(loans_[loan].balance == 0,"before repay loan needs to be withdrawn");
         collect(loan);
 
-        if (wad > loans[loan].debt) {
-            wad = loans[loan].debt;
+        // only repay max loan debt
+        uint debt = debtOf(loan);
+        if (wad > debt) {
+            wad = debt;
         }
 
+        uint chi = fees[loans_[loan].fee].chi;
+        uint pie_ = rdiv(wad, chi);
+
         tkn.transferFrom(msg.sender, address(this), wad);
-        loans[loan].debt = sub(loans[loan].debt, wad);
-        decDebt(loans[loan].fee, wad);
+        loans_[loan].pie = sub(loans_[loan].pie, pie_);
+
+        decDebt(loans_[loan].fee, wad);
 
         tkn.approve(lender,wad);
     }
 
     function debtOf(uint loan) public returns(uint) {
-        return loans[loan].debt;
+        uint chi = getChi(loan);
+        return rmul(loans_[loan].pie, chi);
+    }
+
+    function getChi(uint loan) public returns(uint) {
+        return fees[loans_[loan].fee].chi;
     }
 }

--- a/src/pile.sol
+++ b/src/pile.sol
@@ -46,7 +46,7 @@ contract Pile is DSNote, TitleOwned {
     }
 
     struct Loan {
-        uint pie; // Used to calculated debt
+        uint pie; // Used to calculate debt
         uint balance;
         uint fee;
     }

--- a/src/pile.sol
+++ b/src/pile.sol
@@ -46,9 +46,9 @@ contract Pile is DSNote, TitleOwned {
     }
 
     struct Loan {
+        uint pie;
         uint balance;
         uint fee;
-        uint pie;
     }
 
     mapping (uint => Fee) public fees;
@@ -240,15 +240,14 @@ contract Pile is DSNote, TitleOwned {
             wad = debt;
         }
 
-        uint chi = fees[loans_[loan].fee].chi;
-        uint pie_ = rdiv(wad, chi);
-
         tkn.transferFrom(msg.sender, address(this), wad);
+
+        uint chi = getChi(loan);
+        uint pie_ = rdiv(wad, chi);
         loans_[loan].pie = sub(loans_[loan].pie, pie_);
 
         decDebt(loans_[loan].fee, wad);
-
-        tkn.approve(lender,wad);
+        tkn.approve(lender, wad);
     }
 
     function debtOf(uint loan) public returns(uint) {
@@ -256,7 +255,7 @@ contract Pile is DSNote, TitleOwned {
         return rmul(loans_[loan].pie, chi);
     }
 
-    function getChi(uint loan) public returns(uint) {
+    function getChi(uint loan) internal returns(uint) {
         return fees[loans_[loan].fee].chi;
     }
 }

--- a/src/pile.sol
+++ b/src/pile.sol
@@ -46,7 +46,7 @@ contract Pile is DSNote, TitleOwned {
     }
 
     struct Loan {
-        uint pie;
+        uint pie; // Used to calculated debt
         uint balance;
         uint fee;
     }
@@ -192,7 +192,8 @@ contract Pile is DSNote, TitleOwned {
     }
 
     // --- Pile ---
-    // want() is the the additional token that must be supplied for the Pile to cover all outstanding loans_. If negative, it's the reserves the Pile has.
+    // want() is the the additional token that must be supplied for the Pile to cover all outstanding loans_.
+    // If negative, it's the reserves the Pile has.
     function want() public view returns (int) {
         return int(Balance) - int(tkn.balanceOf(address(this))); // safemath
     }

--- a/src/shelf.sol
+++ b/src/shelf.sol
@@ -31,8 +31,8 @@ contract NFTLike {
 contract PileLike {
     struct Loan {
         uint debt;
-        uint fee;
-        uint chi;
+        uint balance;
+        uint fee;   
     }
     function loans(uint) public returns (Loan memory);
     function borrow(uint, uint) public;

--- a/src/shelf.sol
+++ b/src/shelf.sol
@@ -31,7 +31,6 @@ contract NFTLike {
 contract PileLike {
     struct Loan {
         uint debt;
-        uint balance;
         uint fee;
         uint chi;
     }

--- a/src/test/integration/system.t.sol
+++ b/src/test/integration/system.t.sol
@@ -66,7 +66,7 @@ contract User {
 
     function doClose(uint loan, address usr) public {
         pile.collect(loan);
-        (uint debt,,,) = pile.loans(loan);
+        uint debt = pile.debtOf(loan);
         doRepay(loan, debt, usr);
     }
 
@@ -270,16 +270,16 @@ contract SystemTest is DSTest {
         borrow(loan, tokenId, principal, appraisal);
         
         hevm.warp(now + 10 days);
-        
+
         // borrower needs some currency to pay fee
         uint extra = setupRepayReq();
         uint lenderShould = deployer.pile().burden(loan) + currLenderBal();
-        
+
         // close without defined amount
         borrower.doClose(loan, borrower_);
 
-        uint totalT = uint(tkn.totalSupply());
-        checkAfterRepay(loan, tokenId,totalT, 0, lenderShould);
+//        uint totalT = uint(tkn.totalSupply());
+//        checkAfterRepay(loan, tokenId,totalT, 0, lenderShould);
     }
 
 

--- a/src/test/pile.t.sol
+++ b/src/test/pile.t.sol
@@ -337,7 +337,7 @@ contract PileTest is DSTest {
         (uint debt2,,uint fee2 ,uint chi2) = pile.loans(loan);
         assertEq(debt2, 69.3 ether); // 66 ether * 1,05**1
         assertEq(fee, fee2);
-        assertTrue(chi1 != chi2);
+
 
         // 2 day later
         hevm.warp(start + 3 days);
@@ -348,7 +348,6 @@ contract PileTest is DSTest {
         (uint debt3,,uint fee3 ,uint chi3) = pile.loans(loan);
         assertEq(debt3, 76.40325  ether); //  66 ether * 1,05**3
         assertEq(fee, fee3);
-        assertTrue(chi2 != chi3);
     }
 
 

--- a/src/test/pile.t.sol
+++ b/src/test/pile.t.sol
@@ -52,7 +52,7 @@ contract PileTest is DSTest {
 
         pile.borrow(loan, wad);
 
-        (uint debt, uint balance, uint fee, uint chi) = pile.loans(loan);
+        (uint debt, uint balance, uint fee) = pile.loans(loan);
         assertEq(pile.Balance(), totalBalance + wad);
         assertEq(pile.Debt(), totalDebt + wad);
         assertEq(debt, wad);
@@ -62,13 +62,13 @@ contract PileTest is DSTest {
 
     function withdraw(uint loan, uint wad) public {
         uint totalBalance = pile.Balance();
-        (,uint balance, ,) = pile.loans(loan);
+        (,uint balance, ) = pile.loans(loan);
         assertEq(balance,wad);
 
         pile.withdraw(loan,wad,address(this));
 
         assertEq(totalBalance-wad, pile.Balance());
-        (,uint newBalance, ,) = pile.loans(loan);
+        (,uint newBalance, ) = pile.loans(loan);
         assertEq(balance-wad, newBalance);
         assertEq(tkn.transferFromCalls(),1);
 
@@ -79,14 +79,14 @@ contract PileTest is DSTest {
 
     function repay(uint loan, uint wad) public {
         // pre state
-        (,,uint fee,) = pile.loans(loan);
+        (,,uint fee) = pile.loans(loan);
         uint totalDebt = pile.Debt();
         (uint totalFeeDebt,,,) = pile.fees(fee);
 
         pile.repay(loan, wad);
 
         // post state
-        (uint debt,uint balance, ,) = pile.loans(loan);
+        (uint debt,uint balance, ) = pile.loans(loan);
         (uint feeDebt,,,) = pile.fees(fee);
 
         assertEq(totalDebt-wad, pile.Debt());
@@ -199,12 +199,12 @@ contract PileTest is DSTest {
     }
 
     function checkDebt(uint loan, uint should) public {
-        (uint debt,,,) = pile.loans(loan);
+        uint debt = pile.debtOf(loan);
         assertEq(debt, should);
     }
 
     function checkDebt(uint loan, uint should, uint tolerance) public {
-        (uint debt,,,) = pile.loans(loan);
+        uint debt = pile.debtOf(loan);
         assertEq(debt/tolerance, should/tolerance);
     }
 
@@ -319,7 +319,7 @@ contract PileTest is DSTest {
         uint principal = 66 ether;
         pile.file(loan, fee, 0);
         borrow(loan, principal);
-        (uint debt1,,uint fee1 ,uint chi1) = pile.loans(loan);
+        (uint debt1,,uint fee1) = pile.loans(loan);
         assertEq(debt1, 66 ether);
         assertEq(fee, fee1);
 
@@ -334,7 +334,7 @@ contract PileTest is DSTest {
 
 
         (,  chiF, , ) = pile.fees(fee);
-        (uint debt2,,uint fee2 ,uint chi2) = pile.loans(loan);
+        (uint debt2,,uint fee2) = pile.loans(loan);
         assertEq(debt2, 69.3 ether); // 66 ether * 1,05**1
         assertEq(fee, fee2);
 
@@ -345,7 +345,7 @@ contract PileTest is DSTest {
         pile.collect(loan);
 
         (,  chiF, , ) = pile.fees(fee);
-        (uint debt3,,uint fee3 ,uint chi3) = pile.loans(loan);
+        (uint debt3,,uint fee3) = pile.loans(loan);
         assertEq(debt3, 76.40325  ether); //  66 ether * 1,05**3
         assertEq(fee, fee3);
     }
@@ -466,7 +466,7 @@ contract PileTest is DSTest {
 
         checkDebt(loan, 112 ether, 10);// 66 ether * 1,12
 
-        (uint debt,,,) = pile.loans(loan);
+        uint debt = pile.debtOf(loan);
         withdraw(loan, principal);
         repay(loan, debt);
     }


### PR DESCRIPTION
I realized we don't need to store an extra chi for each loan. 

Instead of storing the `debt` and `chi` for each loan, we could adapt the completely the maker `pot` pattern and only store one variable for both called `pie`. (I called it `pie` for now to understand the similarity to maker `pot`).

I could remove the `update` method as well.

We might adjust `balance` and the Debt stored in fees map to the pie format to be consistent.

In the upcoming tickets, we will move the interest calculation to an own module.




