### PR TITLE
fix: currentJuniorRatio method in assessor zero cases

### DIFF
--- a/bin/util/util.sh
+++ b/bin/util/util.sh
@@ -48,9 +48,10 @@ build_contracts()
     fi
     # build contracts if required
     if [ "$CONTRACT_FILES" -lt  "2" ]; then
-        cd ./../../
+        cd ./../
         dapp update
         dapp build --extract
+        cd bin
     fi
     message contract build files are ready
 }

--- a/src/lender/assessor/base.sol
+++ b/src/lender/assessor/base.sol
@@ -188,6 +188,9 @@ contract BaseAssessor is Math, Auth {
             return ONE;
         }
         uint juniorAssetValue = calcAssetValue(junior);
+        if (juniorAssetValue == 0) {
+            return 0;
+        }
         return rdiv(juniorAssetValue, safeAdd(juniorAssetValue, calcAssetValue(senior)));
     }
 

--- a/src/lender/assessor/test/base.t.sol
+++ b/src/lender/assessor/test/base.t.sol
@@ -241,6 +241,35 @@ contract BaseAssessorTest is DSTest, Math {
         assertEq(assessor.currentJuniorRatio(), 333333333333333333333333333);
     }
 
+    function testCurrentJuniorRatioEdgeCases() public {
+        senior.setReturn("balance", 0);
+        pool.setReturn("totalValue", 0);
+
+        // case juniorAsset == 0 && seniorAsset == 0
+        assertEq(assessor.currentJuniorRatio(), 0);
+
+        pool.setReturn("totalValue", 200 ether);
+
+        // case juniorAsset > 0 && seniorAsset > 0
+        senior.setReturn("debt", 100 ether);
+        assertEq(assessor.calcAssetValue(assessor.junior()), 100 ether);
+        assertEq(assessor.calcAssetValue(assessor.senior()), 100 ether);
+        assertEq(assessor.currentJuniorRatio(), 5*ONE/10);
+
+        //  juniorAsset == 0
+        senior.setReturn("debt", 200 ether);
+        assertEq(assessor.calcAssetValue(assessor.junior()), 0 );
+        assertEq(assessor.calcAssetValue(assessor.senior()), 200 ether);
+        assertEq(assessor.currentJuniorRatio(), 0);
+
+        //  senior == 0
+        senior.setReturn("debt", 0);
+        assertEq(assessor.calcAssetValue(assessor.junior()), 200 ether );
+        assertEq(assessor.calcAssetValue(assessor.senior()), 0);
+        assertEq(assessor.currentJuniorRatio(), ONE);
+
+    }
+
     function testSupplyApprove() public {
         // define minJuniorRatio with 20 %
         uint minJuniorRatio = 2*ONE/10;


### PR DESCRIPTION
- the method didn't prevent zero division in case the junior asset value == 0