### PR TITLE
fix: last total debt decrease

### DIFF
--- a/src/borrower/pile.sol
+++ b/src/borrower/pile.sol
@@ -78,6 +78,12 @@ contract Pile is DSNote, Auth, Interest {
 
         pie[loan] = safeSub(pie[loan], pieAmount);
         rates[rate].pie = safeSub(rates[rate].pie, pieAmount);
+
+        if (currencyAmount > total) {
+            total = 0;
+            return;
+        }
+
         total = safeSub(total, currencyAmount);
     }
 


### PR DESCRIPTION
the `total` debt is not stored in pie format.

Instead, it is increased every time with the delta of a fee group interest update.
See: `safeSub(rmul(updatedChi, pie), rmul(chi, pie)`

Over time and with the different fee groups we noticed small rounding errors (max: `2 wei`)

It results in revert in the last loan repayment in the decDebt method because 
`currencyAmount > total`


