### PR TITLE
chore: file methods for scorecards in NFTFeed and NAVFeed

### DIFF
--- a/src/borrower/feed/navfeed.sol
+++ b/src/borrower/feed/navfeed.sol
@@ -131,7 +131,7 @@ contract NAVFeed is BaseNFTFeed, Interest, Buckets, FixedPoint {
             file("riskGroupNFT", risk_, thresholdRatio_, ceilingRatio_, rate_);
             recoveryRatePD[risk_] = Fixed27(recoveryRatePD_);
 
-        } else {revert ("unkown name");}
+        } else {revert ("unknown name");}
     }
 
     function setWriteOff(uint phase_, uint group_, uint rate_, uint writeOffPercentage_) internal {

--- a/src/borrower/feed/nftfeed.sol
+++ b/src/borrower/feed/nftfeed.sol
@@ -91,7 +91,7 @@ contract BaseNFTFeed is DSNote, Auth, Math {
     }
 
     function file(bytes32 name, uint risk_, uint thresholdRatio_, uint ceilingRatio_, uint rate_) public auth {
-        if(name == "riskGroup") {
+        if(name == "riskGroupNFT") {
             require(ceilingRatio[risk_] == 0, "risk-group-in-usage");
             thresholdRatio[risk_] = thresholdRatio_;
             ceilingRatio[risk_] = ceilingRatio_;

--- a/src/borrower/feed/nftfeed.sol
+++ b/src/borrower/feed/nftfeed.sol
@@ -71,44 +71,6 @@ contract BaseNFTFeed is DSNote, Auth, Math {
      // part of Feed interface
     function file(bytes32 name, uint value) public auth {}
 
-    function init() public {
-        require(thresholdRatio[0] == 0);
-        // The risk groups (scorecard) are custom values for each tinlake deployment
-        // They are pre-defined on contract creation and should not change
-
-        // The following risk groups are just examples that are mostly optimized for the system test cases
-
-        // risk group  => 0
-        // thresholdRatio => 80%
-        // ceilingRatio => 60%
-        // interestRatio: 0%
-        setRiskGroup(0, 8*10**26, 6*10**26, ONE);
-
-        // risk group  => 1
-        // thresholdRatio => 70%
-        // ceilingRatio => 50%
-        // interestRate => 12 % per year
-        setRiskGroup(1, 7*10**26, 5*10**26, uint(1000000003593629043335673583));
-
-        // risk group  => 2
-        // thresholdRatio => 70%
-        // ceilingRatio => 50%
-        // interestRate => 5 % per day
-        setRiskGroup(2, 7*10**26, 5*10**26, uint(1000000564701133626865910626));
-
-        // risk group  => 3
-        // ceiling ratio => 100%
-        // thresholdRatio => 70%
-        // interest rate => 5% per day
-        setRiskGroup(3, 7*10**26, ONE, uint(1000000564701133626865910626));
-
-        // risk group => 4 (used by collector tests)
-        // ceiling ratio => 50%
-        // thresholdRatio => 60%
-        // interest rate => 5% per day
-        setRiskGroup(4, 6*10**26, 5*10**26, uint(1000000564701133626865910626));
-    }
-
     /// sets the dependency to another contract
     function depend(bytes32 contractName, address addr) external auth {
         if (contractName == "pile") {pile = PileLike(addr);}
@@ -128,11 +90,14 @@ contract BaseNFTFeed is DSNote, Auth, Math {
         return nftID(registry, tokenId);
     }
 
-    function setRiskGroup(uint risk_, uint thresholdRatio_, uint ceilingRatio_, uint rate_) internal {
-        thresholdRatio[risk_] = thresholdRatio_;
-        ceilingRatio[risk_] = ceilingRatio_;
-        // set interestRate for risk group
-        pile.file("rate", risk_, rate_);
+    function file(bytes32 name, uint risk_, uint thresholdRatio_, uint ceilingRatio_, uint rate_) public auth {
+        if(name == "riskGroup") {
+            require(ceilingRatio[risk_] == 0, "risk-group-in-usage");
+            thresholdRatio[risk_] = thresholdRatio_;
+            ceilingRatio[risk_] = ceilingRatio_;
+            // set interestRate for risk group
+            pile.file("rate", risk_, rate_);
+        } else {revert ("unkown name");}
     }
 
     ///  -- Oracle Updates --

--- a/src/borrower/feed/test/nftfeed.t.sol
+++ b/src/borrower/feed/test/nftfeed.t.sol
@@ -50,31 +50,31 @@ contract NFTFeedTest is DSTest, Math {
         // thresholdRatio => 80%
         // ceilingRatio => 60%
         // interestRatio: 0%
-        nftFeed.file("riskGroup",0, 8*10**26, 6*10**26, ONE);
+        nftFeed.file("riskGroupNFT",0, 8*10**26, 6*10**26, ONE);
 
         // risk group  => 1
         // thresholdRatio => 70%
         // ceilingRatio => 50%
         // interestRate => 12 % per year
-        nftFeed.file("riskGroup", 1, 7*10**26, 5*10**26, uint(1000000003593629043335673583));
+        nftFeed.file("riskGroupNFT", 1, 7*10**26, 5*10**26, uint(1000000003593629043335673583));
 
         // risk group  => 2
         // thresholdRatio => 70%
         // ceilingRatio => 50%
         // interestRate => 5 % per day
-        nftFeed.file("riskGroup", 2, 7*10**26, 5*10**26, uint(1000000564701133626865910626));
+        nftFeed.file("riskGroupNFT", 2, 7*10**26, 5*10**26, uint(1000000564701133626865910626));
 
         // risk group  => 3
         // ceiling ratio => 100%
         // thresholdRatio => 70%
         // interest rate => 5% per day
-        nftFeed.file("riskGroup", 3, 7*10**26, ONE, uint(1000000564701133626865910626));
+        nftFeed.file("riskGroupNFT", 3, 7*10**26, ONE, uint(1000000564701133626865910626));
 
         // risk group => 4 (used by collector tests)
         // ceiling ratio => 50%
         // thresholdRatio => 60%
         // interest rate => 5% per day
-        nftFeed.file("riskGroup", 4, 6*10**26, 5*10**26, uint(1000000564701133626865910626));
+        nftFeed.file("riskGroupNFT", 4, 6*10**26, 5*10**26, uint(1000000564701133626865910626));
     }
 
     function testBasicNFT() public {

--- a/src/borrower/feed/test/nftfeed.t.sol
+++ b/src/borrower/feed/test/nftfeed.t.sol
@@ -41,12 +41,40 @@ contract NFTFeedTest is DSTest, Math {
         shelf = new ShelfMock();
         nftFeed.depend("shelf", address(shelf));
         nftFeed.depend("pile", address(pile));
-        nftFeed.init();
+        // init scorecard only for NFT Feed
+        init();
     }
 
-    function testFailInit() public {
-        // call init twice
-        nftFeed.init();
+    function init() public {
+        // risk group  => 0
+        // thresholdRatio => 80%
+        // ceilingRatio => 60%
+        // interestRatio: 0%
+        nftFeed.file("riskGroup",0, 8*10**26, 6*10**26, ONE);
+
+        // risk group  => 1
+        // thresholdRatio => 70%
+        // ceilingRatio => 50%
+        // interestRate => 12 % per year
+        nftFeed.file("riskGroup", 1, 7*10**26, 5*10**26, uint(1000000003593629043335673583));
+
+        // risk group  => 2
+        // thresholdRatio => 70%
+        // ceilingRatio => 50%
+        // interestRate => 5 % per day
+        nftFeed.file("riskGroup", 2, 7*10**26, 5*10**26, uint(1000000564701133626865910626));
+
+        // risk group  => 3
+        // ceiling ratio => 100%
+        // thresholdRatio => 70%
+        // interest rate => 5% per day
+        nftFeed.file("riskGroup", 3, 7*10**26, ONE, uint(1000000564701133626865910626));
+
+        // risk group => 4 (used by collector tests)
+        // ceiling ratio => 50%
+        // thresholdRatio => 60%
+        // interest rate => 5% per day
+        nftFeed.file("riskGroup", 4, 6*10**26, 5*10**26, uint(1000000564701133626865910626));
     }
 
     function testBasicNFT() public {
@@ -65,7 +93,7 @@ contract NFTFeedTest is DSTest, Math {
     function assertLoanValuesSetCorrectly(bytes32 nftID, uint nftValue, uint loan, uint riskGroup, bool loanHasDebt) public {
         // check nft value set correctly
         assertEq(nftFeed.nftValues(nftID), nftValue);
-        // check threshold computed correctly 
+        // check threshold computed correctly
         assertEq(nftFeed.threshold(loan), rmul(nftValue, nftFeed.thresholdRatio(riskGroup)));
         // check ceiling computed correctly
         assertEq(nftFeed.currentCeiling(loan),  rmul(nftValue, nftFeed.ceilingRatio(riskGroup)));
@@ -82,7 +110,7 @@ contract NFTFeedTest is DSTest, Math {
         // thresholdRatio => 70%
         // ceilingRatio => 50%
         // interestRate => 12 % per year
-        uint risk = 1; 
+        uint risk = 1;
         bytes32 nftID = nftFeed.nftID(address(1), 1);
         uint loan = 1;
         uint value = 100 ether;
@@ -104,7 +132,7 @@ contract NFTFeedTest is DSTest, Math {
         // thresholdRatio => 70%
         // ceilingRatio => 50%
         // interestRate => 12 % per year
-        uint risk = 1; 
+        uint risk = 1;
         bytes32 nftID = nftFeed.nftID(address(1), 1);
         uint loan = 1;
         uint value = 100 ether;
@@ -127,7 +155,7 @@ contract NFTFeedTest is DSTest, Math {
         // thresholdRatio => 70%
         // ceilingRatio => 50%
         // interestRate => 12 % per year
-        uint risk = 1; 
+        uint risk = 1;
         bytes32 nftID = nftFeed.nftID(address(1), 1);
         uint loan = 1;
         uint value = 100 ether;
@@ -146,11 +174,11 @@ contract NFTFeedTest is DSTest, Math {
         nftFeed.update(nftID, value, risk);
         // // assert all values were set correctly
         assertLoanValuesSetCorrectly(nftID, value, loan, risk, true);
-     }    
-    
+     }
+
     function testFailUpdateRiskGroupDoesNotExist() public {
         // risk group does not exist
-        uint risk = 1000; 
+        uint risk = 1000;
         bytes32 nftID = nftFeed.nftID(address(1), 1);
         uint loan = 1;
         uint value = 100 ether;
@@ -226,21 +254,21 @@ contract NFTFeedTest is DSTest, Math {
 
         // assert values
         assertLoanValuesSetCorrectly(nftID, value, loan, risk, false);
-        
-        
+
+
         uint maxCeiling = nftFeed.ceiling(loan);
         assertEq(nftFeed.ceiling(loan), maxCeiling);
         nftFeed.borrow(loan, maxCeiling);
 
         // decrease nft value, which leads to ceiling decrease
         value = safeDiv(value, 2);
-        // set new nft value 
+        // set new nft value
         nftFeed.update(nftID, value);
 
         // assert new value was set correctly
         assertLoanValuesSetCorrectly(nftID, value, loan, risk, false);
         // new ceiling is smaller then already borrowed amount -> shoul return 0
-        
+
         assertEq(nftFeed.ceiling(loan), 0);
     }
 

--- a/src/borrower/test/deployer.t.sol
+++ b/src/borrower/test/deployer.t.sol
@@ -27,7 +27,7 @@ contract DeployerTest is DSTest {
     TitleFab titlefab;
     ShelfFab shelffab;
     PileFab pilefab;
-    NFTFeedFab nftFeedFab;
+    NAVFeedFab feedFab;
     CollectorFab collectorFab;
     Title title;
 
@@ -38,12 +38,12 @@ contract DeployerTest is DSTest {
         shelffab = new ShelfFab();
         pilefab = new PileFab();
         collectorFab = new CollectorFab();
-        nftFeedFab = new NFTFeedFab();
+        feedFab = new NAVFeedFab();
    }
 
     function testBorrowerDeploy() public logs_gas {
         uint discountRate = uint(1000000342100000000000000000);
-        BorrowerDeployer deployer = new BorrowerDeployer(address(0), titlefab, shelffab, pilefab, collectorFab, address(nftFeedFab), address(dai), "Test", "TEST", discountRate);
+        BorrowerDeployer deployer = new BorrowerDeployer(address(0), titlefab, shelffab, pilefab, collectorFab, address(feedFab), address(dai), "Test", "TEST", discountRate);
 
         deployer.deployTitle();
         deployer.deployPile();


### PR DESCRIPTION
- added file method to NFT Feed for score cards
   - no scorecard by default in NFT Feed
- added file method to NFT Feed for score card with additional recoveryRatePD
- default score card for testing is only initialised in NAV Feed init method