### PR TITLE
fix: safeTransfer for tranche & calcDisburse rounding off

### DIFF
--- a/src/lender/test/tranche.t.sol
+++ b/src/lender/test/tranche.t.sol
@@ -429,7 +429,7 @@ contract TrancheTest is DSTest, Math, FixedPoint {
         // the disburse method should always round off
         ( , uint payoutTokenAmount,, ) =  tranche.calcDisburse(self);
 
-        // rdiv would round up but calc disburse should round off
+        // rdiv would round up in the 20/3 case but calc disburse should always round off
         // 20/3 = 6.666666666666666666 instead of (6.666666666666666667)
         assertEq(rdiv(amount, tokenPrice_)-payoutTokenAmount, 1);
     }

--- a/src/lender/test/tranche.t.sol
+++ b/src/lender/test/tranche.t.sol
@@ -415,4 +415,22 @@ contract TrancheTest is DSTest, Math, FixedPoint {
         assertEq(payoutTokenAmount, rmul(supplyAmount, supplyFulfillment_));
         assertEq(payoutCurrencyAmount, rmul(redeemAmount, redeemFulfillment_));
     }
+
+    function testCalcDisburseRoundingOff() public {
+        uint amount = 20 ether;
+        supplyOrder(amount);
+
+        uint supplyFulfillment_ = ONE;
+        uint redeemFulfillment_ = ONE;
+        uint tokenPrice_ = 3 * 10 ** 27;
+
+        closeAndUpdate(supplyFulfillment_, redeemFulfillment_, tokenPrice_);
+
+        // the disburse method should always round off
+        ( , uint payoutTokenAmount,, ) =  tranche.calcDisburse(self);
+
+        // rdiv would round up but calc disburse should round off
+        // 20/3 = 6.666666666666666666 instead of (6.666666666666666667)
+        assertEq(rdiv(amount, tokenPrice_)-payoutTokenAmount, 1);
+    }
 }

--- a/src/lender/tranche.sol
+++ b/src/lender/tranche.sol
@@ -173,7 +173,7 @@ contract Tranche is Math, Auth, FixedPoint {
                 amount = rmul(remainingSupplyCurrency, epochs[epochIdx].supplyFulfillment.value);
                 // supply currency payout in token
                 if (amount != 0) {
-                    payoutTokenAmount = safeAdd(payoutTokenAmount, rdiv(amount, epochs[epochIdx].tokenPrice.value));
+                    payoutTokenAmount = safeAdd(payoutTokenAmount, safeDiv(safeMul(amount, ONE), epochs[epochIdx].tokenPrice.value));
                     remainingSupplyCurrency = safeSub(remainingSupplyCurrency, amount);
                 }
             }

--- a/src/lender/tranche.sol
+++ b/src/lender/tranche.sol
@@ -19,7 +19,6 @@ pragma experimental ABIEncoderV2;
 import "tinlake-auth/auth.sol";
 import "tinlake-math/math.sol";
 import "./../fixed_point.sol";
-import "../../lib/tinlake-erc20/src/erc20.sol";
 
 interface ERC20Like {
     function balanceOf(address) external view returns (uint);


### PR DESCRIPTION
- if the tranche doesn't have enough currency or token instead of failing  the user should receive the maximum possible amount
- calcDisburse should always round off instead of round up instead of depending if the last value is `> 5` or `< 5`
