### PR TITLE
feat: recovery transfer for tranche

### DIFF
--- a/src/lender/test/tranche.t.sol
+++ b/src/lender/test/tranche.t.sol
@@ -28,7 +28,7 @@ contract Hevm {
 
 contract User {
     function authTransfer(Tranche tranche, address erc20, address usr, uint amount) public {
-        tranche.recoveryTransfer(erc20, usr, amount);
+        tranche.authTransfer(erc20, usr, amount);
     }
 }
 
@@ -427,7 +427,7 @@ contract TrancheTest is DSTest, Math, FixedPoint {
         supplyOrder(amount);
 
         assertEq(currency.balanceOf(address(tranche)), amount);
-        tranche.recoveryTransfer(address(currency), recoveryAddr, amount);
+        tranche.authTransfer(address(currency), recoveryAddr, amount);
         assertEq(currency.balanceOf(recoveryAddr), amount);
         assertEq(currency.balanceOf(address(tranche)), 0);
     }
@@ -440,7 +440,7 @@ contract TrancheTest is DSTest, Math, FixedPoint {
         assertEq(currency.balanceOf(address(tranche)), amount);
 
         User nonAdminUser = new User();
-        nonAdminUser.recoveryTransfer(tranche, address(currency), recoveryAddr, amount);
+        nonAdminUser.authTransfer(tranche, address(currency), recoveryAddr, amount);
     }
 
     function testCalcDisburseRoundingOff() public {

--- a/src/lender/test/tranche.t.sol
+++ b/src/lender/test/tranche.t.sol
@@ -27,7 +27,7 @@ contract Hevm {
 }
 
 contract User {
-    function recoveryTransfer(Tranche tranche, address erc20, address usr, uint amount) public {
+    function authTransfer(Tranche tranche, address erc20, address usr, uint amount) public {
         tranche.recoveryTransfer(erc20, usr, amount);
     }
 }

--- a/src/lender/test/tranche.t.sol
+++ b/src/lender/test/tranche.t.sol
@@ -26,6 +26,12 @@ contract Hevm {
     function warp(uint256) public;
 }
 
+contract User {
+    function recoveryTransfer(Tranche tranche, address erc20, address usr, uint amount) public {
+        tranche.recoveryTransfer(erc20, usr, amount);
+    }
+}
+
 contract TrancheTest is DSTest, Math, FixedPoint {
     Tranche tranche;
     SimpleToken token;
@@ -424,6 +430,17 @@ contract TrancheTest is DSTest, Math, FixedPoint {
         tranche.recoveryTransfer(address(currency), recoveryAddr, amount);
         assertEq(currency.balanceOf(recoveryAddr), amount);
         assertEq(currency.balanceOf(address(tranche)), 0);
+    }
+
+    function testFailRecoveryTransferNotAdmin() public {
+        uint amount = 100 ether;
+        address recoveryAddr = address(123);
+        supplyOrder(amount);
+
+        assertEq(currency.balanceOf(address(tranche)), amount);
+
+        User nonAdminUser = new User();
+        nonAdminUser.recoveryTransfer(tranche, address(currency), recoveryAddr, amount);
     }
 
     function testCalcDisburseRoundingOff() public {

--- a/src/lender/test/tranche.t.sol
+++ b/src/lender/test/tranche.t.sol
@@ -21,7 +21,6 @@ import "tinlake-math/math.sol";
 import "./../tranche.sol";
 import "../../test/simple/token.sol";
 import "../test/mock/reserve.sol";
-import "../../../lib/tinlake-erc20/src/erc20.sol";
 
 contract Hevm {
     function warp(uint256) public;

--- a/src/lender/test/tranche.t.sol
+++ b/src/lender/test/tranche.t.sol
@@ -415,4 +415,15 @@ contract TrancheTest is DSTest, Math, FixedPoint {
         assertEq(payoutTokenAmount, rmul(supplyAmount, supplyFulfillment_));
         assertEq(payoutCurrencyAmount, rmul(redeemAmount, redeemFulfillment_));
     }
+
+    function testRecoveryTransfer() public {
+        uint amount = 100 ether;
+        address recoveryAddr = address(123);
+        supplyOrder(amount);
+
+        assertEq(currency.balanceOf(address(tranche)), amount);
+        tranche.recoveryTransfer(address(currency), recoveryAddr, amount);
+        assertEq(currency.balanceOf(recoveryAddr), amount);
+        assertEq(currency.balanceOf(address(tranche)), 0);
+    }
 }

--- a/src/lender/tranche.sol
+++ b/src/lender/tranche.sol
@@ -19,6 +19,7 @@ pragma experimental ABIEncoderV2;
 import "tinlake-auth/auth.sol";
 import "tinlake-math/math.sol";
 import "./../fixed_point.sol";
+import "../../lib/tinlake-erc20/src/erc20.sol";
 
 interface ERC20Like {
     function balanceOf(address) external view returns (uint);
@@ -324,5 +325,10 @@ contract Tranche is Math, Auth, FixedPoint {
             // get missing currency from reserve
             safePayout(diff);
         }
+    }
+
+    // recovery transfer can be used by governance to recover funds if tokens are stuck
+    function recoveryTransfer(address erc20, address usr, uint amount) public auth {
+        ERC20Like(erc20).transferFrom(self, usr, amount);
     }
 }

--- a/src/lender/tranche.sol
+++ b/src/lender/tranche.sol
@@ -335,7 +335,7 @@ contract Tranche is Math, Auth, FixedPoint {
     }
 
     // recovery transfer can be used by governance to recover funds if tokens are stuck
-    function recoveryTransfer(address erc20, address usr, uint amount) public auth {
+    function authTransfer(address erc20, address usr, uint amount) public auth {
         ERC20Like(erc20).transferFrom(self, usr, amount);
     }
 }

--- a/src/lender/tranche.sol
+++ b/src/lender/tranche.sol
@@ -19,7 +19,6 @@ pragma experimental ABIEncoderV2;
 import "tinlake-auth/auth.sol";
 import "tinlake-math/math.sol";
 import "./../fixed_point.sol";
-import "../../lib/tinlake-erc20/src/erc20.sol";
 
 interface ERC20Like {
     function balanceOf(address) external view returns (uint);


### PR DESCRIPTION
- recovery transfer allows governance to intervene if tokens get stuck in the tranche contract
- long term method should be removed but for the first deployments it is an additional security mechanism to avoid locked funds 
