### PR TITLE
fix: improvementScore condition in coordinator

### DIFF
--- a/src/lender/coordinator.sol
+++ b/src/lender/coordinator.sol
@@ -101,8 +101,8 @@ contract EpochCoordinator is Auth, Math, FixedPoint  {
                         // highest priority senior redeem and junior redeem before junior and senior supply
     uint                public weightSeniorRedeem  = 1000000;
     uint                public weightJuniorRedeem  =  100000;
-    uint                public weightsJuniorSupply =   10000;
-    uint                public weightsSeniorSupply =    1000;
+    uint                public weightJuniorSupply =   10000;
+    uint                public weightSeniorSupply =    1000;
 
                         // challenge period end timestamp
     uint                public minChallengePeriodEnd;
@@ -148,8 +148,8 @@ contract EpochCoordinator is Auth, Math, FixedPoint  {
             minimumEpochTime = value;
         } else if (name == "weightSeniorRedeem") { weightSeniorRedeem = value;}
           else if (name == "weightJuniorRedeem") { weightJuniorRedeem = value;}
-          else if (name == "weightsJuniorSupply") { weightsJuniorSupply = value;}
-          else if (name == "weightsSeniorSupply") { weightsSeniorSupply = value;}
+          else if (name == "weightJuniorSupply") { weightJuniorSupply = value;}
+          else if (name == "weightSeniorSupply") { weightSeniorSupply = value;}
           else { revert("unkown-name");}
      }
 
@@ -424,7 +424,7 @@ contract EpochCoordinator is Auth, Math, FixedPoint  {
         // 3. junior supply
         // 4. senior supply
         return safeAdd(safeAdd(safeMul(seniorRedeem, weightSeniorRedeem), safeMul(juniorRedeem, weightJuniorRedeem)),
-            safeAdd(safeMul(juniorSupply, weightsJuniorSupply), safeMul(seniorSupply, weightsSeniorSupply)));
+            safeAdd(safeMul(juniorSupply, weightJuniorSupply), safeMul(seniorSupply, weightSeniorSupply)));
     }
 
     /// validates if a solution satisfy the core constraints

--- a/src/lender/coordinator.sol
+++ b/src/lender/coordinator.sol
@@ -406,7 +406,7 @@ contract EpochCoordinator is Auth, Math, FixedPoint  {
         // only if the submitted solution ratio score equals the current best ratio
         // we determine if the submitted solution improves the reserve
         if (impScoreRatio == bestRatioImprovement) {
-              if (impScoreReserve > bestReserveImprovement) {
+              if (impScoreReserve >= bestReserveImprovement) {
                   return (NEW_BEST, impScoreRatio, impScoreReserve);
               }
         }


### PR DESCRIPTION
**Summary**
- it should be possible to submit the current state (submission with only zeros) to start the challenge period
  - in some cases it is not possible to submit a solution which is improving the current state
  - Example: maxReserve violated and only supply orders and no redeem orders (the only solution is a zero submission)
  - it should be allowed to submit a zero submission to start the challenge period
- fix typo in weights name


**Details**
In an improvement scenario we calculate the improvement score of the current state. The improvement score of the current state is used as benchmark for the submitted solution. A current state submission should be accepted as an improvement.