### PR TITLE
feat: definitions contract & assessor.changeSeniorAsset

### DIFF
--- a/src/borrower/feed/test/navfeed.t.sol
+++ b/src/borrower/feed/test/navfeed.t.sol
@@ -200,7 +200,7 @@ contract NAVTest is DSTest, Math {
         uint tokenId = 1;
         uint dueDate = now + 2 days;
         uint amount = 40 ether;
-        uint fixedFeeRate = 25*10**25; // 25 % -> 10 ether 
+        uint fixedFeeRate = 25*10**25; // 25 % -> 10 ether
         pile.setReturn("rates_fixedRate", fixedFeeRate);
         (,,uint NAVIncrease) = borrow(tokenId, nftValue, amount, dueDate);
         // // check FV
@@ -269,7 +269,7 @@ contract NAVTest is DSTest, Math {
 
     function testRepay() public {
         uint amount = 50 ether;
-        
+
         setupLinkedListBuckets();
 
         // due date + 5 days for loan 2
@@ -323,12 +323,10 @@ contract NAVTest is DSTest, Math {
     function testChangeMaturityDateNoDebt() public {
         uint nftValue = 100 ether;
         uint tokenId = 1;
-        uint loan = 1;
         uint dueDate = now + 2 days;
-        uint amount = 50 ether;
         bytes32 nftID = prepareDefaultNFT(tokenId, nftValue);
         // should fail switching to new date after borrowing
-        
+
         feed.file("maturityDate", nftID, dueDate);
         // no loan debt exists -> maturity date change possible
         uint newDate = dueDate + 2 days;
@@ -348,15 +346,12 @@ contract NAVTest is DSTest, Math {
     }
 
     function testRepayAfterMaturityDate() public {
-        uint amount = 50 ether;
         setupLinkedListBuckets();
         // due date + 5 days for loan 2
-        uint tokenId = 2;
         uint loan = 2;
         uint repaymentAmount = 30 ether;
         bytes32 nftID = feed.nftID(loan);
         uint maturityDate = feed.maturityDate(nftID);
-        uint nav = feed.currentNAV();
         uint approximatedNav = feed.approximatedNAV();
         uint futureValue = feed.futureValue(nftID);
         // assert future value of loan is bigger then 0

--- a/src/lender/assessor.sol
+++ b/src/lender/assessor.sol
@@ -14,9 +14,9 @@
 
 pragma solidity >=0.5.15 <0.6.0;
 
-import "./../fixed_point.sol";
 import "tinlake-auth/auth.sol";
 import "tinlake-math/interest.sol";
+import "./definitions.sol";
 
 interface NAVFeedLike {
     function calcUpdateNAV() external returns (uint);
@@ -33,7 +33,7 @@ interface ReserveLike {
     function file(bytes32 what, uint currencyAmount) external;
 }
 
-contract Assessor is Auth, FixedPoint, Interest {
+contract Assessor is Definitions, Auth, Interest {
     // senior ratio from the last epoch executed
     Fixed27        public seniorRatio;
 
@@ -95,6 +95,20 @@ contract Assessor is Auth, FixedPoint, Interest {
         else {revert("unknown-variable");}
     }
 
+    // todo maybe not required
+    function reBalance() public {
+        uint seniorAsset_ = safeAdd(dripSeniorDebt(), seniorBalance_);
+        uint nav_ = navFeed.approximatedNAV();
+        uint reserve_ = reserve.totalBalance();
+
+        uint assets = safeAdd(nav_, reserve_);
+        if(assets == 0) {
+            return;
+        }
+
+        reBalance(seniorAsset_, rdiv(seniorAsset_, assets));
+    }
+
     function reBalance(uint seniorAsset_, uint seniorRatio_) internal {
         // re-balancing according to new ratio
         // we use the approximated NAV here because during the submission period
@@ -108,6 +122,22 @@ contract Assessor is Auth, FixedPoint, Interest {
         seniorBalance_ = safeSub(seniorAsset_, seniorDebt_);
     }
 
+    // todo method WIP
+    function changeSeniorBalance(uint seniorSupply, uint seniorRedeem) external auth {
+        uint seniorAsset_ = safeSub(safeAdd(safeAdd(dripSeniorDebt(), seniorBalance_),seniorSupply), seniorRedeem);
+
+        uint nav_ = navFeed.approximatedNAV();
+        uint reserve_ = reserve.totalBalance();
+
+        uint assets = safeAdd(nav_, reserve_);
+        if(assets == 0) {
+            return;
+        }
+
+        reBalance(seniorAsset_, rdiv(seniorAsset_, assets));
+    }
+
+    // todo legacy method
     function changeSeniorAsset(uint seniorRatio_, uint seniorSupply, uint seniorRedeem) external auth {
         dripSeniorDebt();
         uint seniorAsset = safeSub(safeAdd(safeAdd(seniorDebt_, seniorBalance_),seniorSupply), seniorRedeem);
@@ -147,7 +177,7 @@ contract Assessor is Auth, FixedPoint, Interest {
             return ONE;
         }
         uint totalAssets = safeAdd(epochNAV, epochReserve);
-        uint seniorAssetValue = calcSeniorAssetValue(seniorDebt(), seniorBalance_);
+        uint seniorAssetValue = calcExpectedSeniorAsset(seniorDebt(), seniorBalance_);
 
         if(totalAssets < seniorAssetValue) {
             seniorAssetValue = totalAssets;
@@ -161,7 +191,7 @@ contract Assessor is Auth, FixedPoint, Interest {
             return ONE;
         }
         uint totalAssets = safeAdd(epochNAV, epochReserve);
-        uint seniorAssetValue = calcSeniorAssetValue(seniorDebt(), seniorBalance_);
+        uint seniorAssetValue = calcExpectedSeniorAsset(seniorDebt(), seniorBalance_);
 
         if(totalAssets < seniorAssetValue) {
             return 0;
@@ -178,7 +208,7 @@ contract Assessor is Auth, FixedPoint, Interest {
         uint decAmount = rmul(currencyAmount, seniorRatio.value);
 
         if (decAmount > seniorDebt_) {
-            seniorBalance_ = calcSeniorAssetValue(seniorDebt_, seniorBalance_);
+            seniorBalance_ = calcExpectedSeniorAsset(seniorDebt_, seniorBalance_);
             seniorDebt_ = 0;
             return;
         }
@@ -201,7 +231,7 @@ contract Assessor is Auth, FixedPoint, Interest {
         // this case should most likely never happen
         if (incAmount > seniorBalance_) {
             // all the currency of senior is used as interest bearing currencyAmount
-            seniorDebt_ = calcSeniorAssetValue(seniorDebt_, seniorBalance_);
+            seniorDebt_ = calcExpectedSeniorAsset(seniorDebt_, seniorBalance_);
             seniorBalance_ = 0;
             return;
         }
@@ -212,9 +242,7 @@ contract Assessor is Auth, FixedPoint, Interest {
         lastUpdateSeniorInterest = block.timestamp;
     }
 
-    function calcSeniorAssetValue(uint _seniorDebt, uint _seniorBalance) public pure returns(uint) {
-        return safeAdd(_seniorDebt, _seniorBalance);
-    }
+
 
     function dripSeniorDebt() public returns (uint) {
         uint newSeniorDebt = seniorDebt();

--- a/src/lender/coordinator.sol
+++ b/src/lender/coordinator.sol
@@ -508,8 +508,8 @@ contract EpochCoordinator is Auth, Math, FixedPoint  {
                 juniorSupply: juniorSupply}));
     }
 
-    function validate(uint reserve, uint nav, uint seniorAsset, OrderSummary memory trans) view public returns (int) {
-        uint currencyAvailable = safeAdd(safeAdd(reserve, trans.seniorSupply), trans.juniorSupply);
+    function validate(uint reserve_, uint nav_, uint seniorAsset_, OrderSummary memory trans) view public returns (int) {
+        uint currencyAvailable = safeAdd(safeAdd(reserve_, trans.seniorSupply), trans.juniorSupply);
         uint currencyOut = safeAdd(trans.seniorRedeem, trans.juniorRedeem);
 
         int err = validateCoreConstraints(currencyAvailable, currencyOut, trans.seniorRedeem,
@@ -528,7 +528,7 @@ contract EpochCoordinator is Auth, Math, FixedPoint  {
 
         }
         return validatePoolConstraints(newReserve, assessor.calcSeniorAssetValue(trans.seniorRedeem, trans.seniorSupply,
-            seniorAsset, newReserve, nav), nav);
+            seniorAsset_, newReserve, nav_), nav_);
     }
 
     /// public method to execute an epoch which required a submission period and the challenge period is over

--- a/src/lender/definitions.sol
+++ b/src/lender/definitions.sol
@@ -24,12 +24,14 @@ contract Definitions is FixedPoint, Math {
     }
 
     /// calculates the senior ratio
-    function calcSeniorRatio(uint seniorAsset, uint NAV, uint reserve_) public pure returns(uint) {
+    function calcSeniorRatio(uint seniorAsset, uint nav, uint reserve_) public pure returns(uint) {
         // note: NAV + reserve == seniorAsset + juniorAsset (loop invariant: always true)
-        uint assets = calcAssets(NAV, reserve_);
+        // if expectedSeniorAsset is passed ratio can be greater than ONE
+        uint assets = calcAssets(nav, reserve_);
         if(assets == 0) {
             return 0;
         }
+
         return rdiv(seniorAsset, assets);
     }
 
@@ -56,5 +58,10 @@ contract Definitions is FixedPoint, Math {
         }
 
         return seniorAsset;
+    }
+
+    // expected senior return if no losses occur
+    function calcExpectedSeniorAsset(uint seniorRedeem, uint seniorSupply, uint seniorBalance_, uint seniorDebt_) public returns(uint) {
+        return safeSub(safeAdd(safeAdd(seniorDebt_, seniorBalance_),seniorSupply), seniorRedeem);
     }
 }

--- a/src/lender/definitions.sol
+++ b/src/lender/definitions.sol
@@ -1,0 +1,60 @@
+// Copyright (C) 2020 Centrifuge
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+pragma solidity >=0.5.15 <0.6.0;
+
+import "tinlake-math/math.sol";
+import "./../fixed_point.sol";
+
+// contract without a state which defines the relevant formulars for the assessor
+contract Definitions is FixedPoint, Math {
+    function calcExpectedSeniorAsset(uint _seniorDebt, uint _seniorBalance) public pure returns(uint) {
+        return safeAdd(_seniorDebt, _seniorBalance);
+    }
+
+    /// calculates the senior ratio
+    function calcSeniorRatio(uint seniorAsset, uint NAV, uint reserve_) public pure returns(uint) {
+        // note: NAV + reserve == seniorAsset + juniorAsset (loop invariant: always true)
+        uint assets = calcAssets(NAV, reserve_);
+        if(assets == 0) {
+            return 0;
+        }
+        return rdiv(seniorAsset, assets);
+    }
+
+    function calcSeniorRatio(uint seniorRedeem, uint seniorSupply,
+            uint currSeniorAsset, uint newReserve, uint nav) public pure returns (uint seniorRatio)  {
+        return calcSeniorRatio(calcSeniorAssetValue(seniorRedeem, seniorSupply,
+            currSeniorAsset, newReserve, nav), nav, newReserve);
+    }
+
+/// calculates the net wealth in the system
+    /// NAV for ongoing loans and currency in reserve
+    function calcAssets(uint NAV, uint reserve_) public pure returns(uint) {
+        return safeAdd(NAV, reserve_);
+    }
+
+    /// calculates a new senior asset value based on senior redeem and senior supply
+    function calcSeniorAssetValue(uint seniorRedeem, uint seniorSupply,
+        uint currSeniorAsset, uint reserve_, uint nav_) public pure returns (uint seniorAsset) {
+
+        seniorAsset =  safeSub(safeAdd(currSeniorAsset, seniorSupply), seniorRedeem);
+        uint assets = calcAssets(nav_, reserve_);
+        if(seniorAsset > assets) {
+            seniorAsset = assets;
+        }
+
+        return seniorAsset;
+    }
+}

--- a/src/lender/fabs/assessoradmin.sol
+++ b/src/lender/fabs/assessoradmin.sol
@@ -18,7 +18,7 @@ pragma solidity >=0.5.15 <0.6.0;
 import { AssessorAdmin } from "./../admin/assessor.sol";
 
 contract AssessorAdminFab {
-    function newAssessorAdmin() public returns (address assessorAdmin) {
+    function newAssessorAdmin() public returns (address) {
         AssessorAdmin assessorAdmin = new AssessorAdmin();
 
         assessorAdmin.rely(msg.sender);

--- a/src/lender/test/assessor.t.sol
+++ b/src/lender/test/assessor.t.sol
@@ -272,11 +272,10 @@ contract AssessorTest is DSTest, Math {
         reserveMock.setReturn("balance", 200 ether);
 
         uint seniorSupply = 200 ether;
-        uint seniorRatio = 5 * 10**26;
 
         // seniorRatio 50%
         assessor.changeSeniorAsset(seniorSupply, 0);
-        
+
         assertEq(assessor.seniorDebt(), 100 ether);
         assertEq(assessor.seniorBalance(), 100 ether);
 

--- a/src/lender/test/assessor.t.sol
+++ b/src/lender/test/assessor.t.sol
@@ -120,9 +120,14 @@ contract AssessorTest is DSTest, Math {
         assertEq(assessor.seniorBalance(), 0);
         assertEq(assessor.seniorDebt(), 0);
 
-        uint seniorSupply = 200 ether;
-        uint seniorRatio = 6 * 10**26;
-        assessor.changeSeniorAsset(seniorRatio, seniorSupply, 0);
+
+        navFeed.setReturn("approximatedNAV", 0 ether);
+        reserveMock.setReturn("balance", 1000 ether);
+
+
+        uint seniorSupply = 800 ether;
+        uint seniorRatio = 0.8 * 10**27;
+        assessor.changeSeniorAsset(seniorSupply, 0);
         assertEq(assessor.seniorRatio(), seniorRatio);
 
         assessor.borrowUpdate(currencyAmount);
@@ -134,7 +139,7 @@ contract AssessorTest is DSTest, Math {
 
 
         // very high increase very rare case
-        currencyAmount = 1000 ether;
+        currencyAmount = 10000 ether;
         assessor.borrowUpdate(currencyAmount);
 
         assertEq(assessor.seniorDebt(), seniorSupply);
@@ -142,29 +147,55 @@ contract AssessorTest is DSTest, Math {
     }
 
     function testChangeSeniorAsset() public {
-        uint seniorSupply =  100 ether;
+        uint seniorSupply =  80 ether;
         uint seniorRedeem = 0;
-        uint seniorRatio = 6 * 10**26;
-        assessor.changeSeniorAsset(seniorRatio, seniorSupply, seniorRedeem);
-
-        // NAV = 0
-        assertEq(assessor.seniorDebt(), 0);
-        assertEq(assessor.seniorBalance(), seniorSupply);
 
         navFeed.setReturn("approximatedNAV", 10 ether);
-        // update with no change
-        assessor.changeSeniorAsset(seniorRatio, 0, 0);
+        reserveMock.setReturn("balance", 90 ether);
 
-        assertEq(assessor.seniorDebt(), 6 ether);
-        assertEq(assessor.seniorBalance(), 94 ether);
 
-        seniorSupply = 10 ether;
-        seniorRedeem = 4 ether;
-        // net increase of 6 ether
-        assessor.changeSeniorAsset(seniorRatio, seniorSupply, seniorRedeem);
+        assessor.changeSeniorAsset(seniorSupply, seniorRedeem);
+        assertEq(assessor.seniorDebt(), 8 ether);
+        assertEq(assessor.seniorBalance(), seniorSupply - 8 ether);
+    }
 
-        assertEq(assessor.seniorDebt(), 6 ether);
-        assertEq(assessor.seniorBalance(), 100 ether);
+    function testChangeSeniorAssetOnlySenior() public {
+        uint seniorSupply =  100 ether;
+        uint seniorRedeem = 0;
+
+        navFeed.setReturn("approximatedNAV", 10 ether);
+        reserveMock.setReturn("balance", 90 ether);
+
+
+        assessor.changeSeniorAsset(seniorSupply, seniorRedeem);
+        assertEq(assessor.seniorDebt(), 10 ether);
+        assertEq(assessor.seniorBalance(), seniorSupply - 10 ether);
+    }
+
+    function testChangeSeniorAssetNoNAV() public {
+        uint seniorSupply =  100 ether;
+        uint seniorRedeem = 0;
+
+        navFeed.setReturn("approximatedNAV", 0);
+        reserveMock.setReturn("balance", 120 ether);
+
+
+        assessor.changeSeniorAsset(seniorSupply, seniorRedeem);
+        assertEq(assessor.seniorDebt(), 0);
+        assertEq(assessor.seniorBalance(), seniorSupply);
+    }
+
+    function testChangeSeniorAssetFullSenior() public {
+        uint seniorSupply =  100 ether;
+        uint seniorRedeem = 0;
+
+        navFeed.setReturn("approximatedNAV", 10 ether);
+        reserveMock.setReturn("balance", 50 ether);
+
+
+        assessor.changeSeniorAsset(seniorSupply, seniorRedeem);
+        assertEq(assessor.seniorDebt(), 10 ether);
+        assertEq(assessor.seniorBalance(), 90 ether);
     }
 
     function testRepayUpdate() public {
@@ -174,29 +205,32 @@ contract AssessorTest is DSTest, Math {
         assertEq(assessor.seniorBalance(), 0);
         assertEq(assessor.seniorDebt(), 0);
 
-        uint seniorSupply = 200 ether;
-        uint seniorRatio = 6 * 10**26;
+        navFeed.setReturn("approximatedNAV", 0 ether);
+        reserveMock.setReturn("balance", 1000 ether);
 
-        assessor.changeSeniorAsset(seniorRatio, seniorSupply, 0);
+        uint seniorSupply = 800 ether;
+        uint seniorRatio = 0.8 * 10**27;
+
+        assessor.changeSeniorAsset(seniorSupply, 0);
         assertEq(assessor.seniorRatio(), seniorRatio);
         // NAV = 0
-        assertEq(assessor.seniorBalance(), 200 ether);
+        assertEq(assessor.seniorBalance(), 800 ether);
 
         // required to borrow first
         uint borrowAmount = 100 ether;
         assessor.borrowUpdate(borrowAmount);
         // 100 * 0.6 = 60 ether
-        assertEq(assessor.seniorDebt(), 60 ether);
-        assertEq(assessor.seniorBalance(), 140 ether);
+        assertEq(assessor.seniorDebt(), 80 ether);
+        assertEq(assessor.seniorBalance(), 720 ether);
 
-        // 60 ether
+        // 80 ether
         assertEq(assessor.seniorDebt(), rmul(borrowAmount, seniorRatio));
         repayAmount = 50 ether;
 
         assessor.repaymentUpdate(repayAmount);
-        // 50 * 0.6 = 30 ether
-        assertEq(assessor.seniorDebt(), 30 ether);
-        assertEq(assessor.seniorBalance(), 170 ether);
+        // 50 * 0.8 = 30 ether
+        assertEq(assessor.seniorDebt(), 40 ether);
+        assertEq(assessor.seniorBalance(), 760 ether);
     }
 
     function testSeniorInterest() public {
@@ -205,11 +239,12 @@ contract AssessorTest is DSTest, Math {
         assessor.file("seniorInterestRate", interestRate);
 
         navFeed.setReturn("approximatedNAV", 200 ether);
+        reserveMock.setReturn("balance", 200 ether);
 
         uint seniorSupply = 200 ether;
-        uint seniorRatio = 5 * 10**26;
 
-        assessor.changeSeniorAsset(seniorRatio, seniorSupply, 0);
+        // seniorRatio 50%
+        assessor.changeSeniorAsset(seniorSupply, 0);
         assertEq(assessor.seniorDebt(), 100 ether);
         assertEq(assessor.seniorBalance(), 100 ether);
 
@@ -234,11 +269,14 @@ contract AssessorTest is DSTest, Math {
         assertEq(seniorTokenPrice, ONE);
 
         navFeed.setReturn("approximatedNAV", 200 ether);
+        reserveMock.setReturn("balance", 200 ether);
 
         uint seniorSupply = 200 ether;
         uint seniorRatio = 5 * 10**26;
 
-        assessor.changeSeniorAsset(seniorRatio, seniorSupply, 0);
+        // seniorRatio 50%
+        assessor.changeSeniorAsset(seniorSupply, 0);
+        
         assertEq(assessor.seniorDebt(), 100 ether);
         assertEq(assessor.seniorBalance(), 100 ether);
 
@@ -280,10 +318,13 @@ contract AssessorTest is DSTest, Math {
 
         // set up senior asset
         navFeed.setReturn("approximatedNAV", 200 ether);
-        uint seniorSupply = 200 ether;
-        uint seniorRatio = 5 * 10**26;
+        reserveMock.setReturn("balance", 200 ether);
 
-        assessor.changeSeniorAsset(seniorRatio, seniorSupply, 0);
+        uint seniorSupply = 200 ether;
+
+        // seniorRatio 50%
+        assessor.changeSeniorAsset(seniorSupply, 0);
+
         assertEq(assessor.seniorDebt(), 100 ether);
         assertEq(assessor.seniorBalance(), 100 ether);
 
@@ -326,10 +367,12 @@ contract AssessorTest is DSTest, Math {
 
 
         navFeed.setReturn("approximatedNAV", 200 ether);
-        uint seniorSupply = 200 ether;
-        uint seniorRatio = 5 * 10**26;
+        reserveMock.setReturn("balance", 200 ether);
 
-        assessor.changeSeniorAsset(seniorRatio, seniorSupply, 0);
+        uint seniorSupply = 200 ether;
+
+        // seniorRatio 50%
+        assessor.changeSeniorAsset(seniorSupply, 0);
         assertEq(assessor.seniorDebt(), 100 ether);
         assertEq(assessor.seniorBalance(), 100 ether);
 

--- a/src/lender/test/coordinator-base.t.sol
+++ b/src/lender/test/coordinator-base.t.sol
@@ -20,6 +20,7 @@ import "ds-test/test.sol";
 import "tinlake-math/math.sol";
 
 import "./../coordinator.sol";
+import "./../definitions.sol";
 import "./mock/tranche.sol";
 import "./mock/reserve.sol";
 import "./mock/assessor.sol";
@@ -71,6 +72,8 @@ contract CoordinatorLike is BaseTypes {
     function submitSolution(uint,uint,uint,uint) public returns (int);
 }
 
+contract AssessorMockWithDef is AssessorMock, Definitions { }
+
 contract CoordinatorTest is DSTest, Math, BaseTypes {
     Hevm hevm;
     EpochCoordinator coordinator;
@@ -78,7 +81,7 @@ contract CoordinatorTest is DSTest, Math, BaseTypes {
     TrancheMock seniorTranche;
     TrancheMock juniorTranche;
 
-    AssessorMock assessor;
+    AssessorMockWithDef assessor;
 
     ReserveMock reserve;
 
@@ -96,7 +99,7 @@ contract CoordinatorTest is DSTest, Math, BaseTypes {
         seniorTranche = new TrancheMock();
         juniorTranche = new TrancheMock();
         reserve = new ReserveMock(address(0));
-        assessor = new AssessorMock();
+        assessor = new AssessorMockWithDef();
 
         seniorTranche_ = address(seniorTranche);
         juniorTranche_ = address(juniorTranche);

--- a/src/lender/test/coordinator-closeEpoch.t.sol
+++ b/src/lender/test/coordinator-closeEpoch.t.sol
@@ -97,7 +97,6 @@ contract CoordinatorCloseEpochTest is CoordinatorTest {
         coordinator.closeEpoch();
         assertEq(coordinator.lastEpochExecuted(), 1);
         assertTrue(coordinator.submissionPeriod() == false);
-        assertEq(assessor.values_uint("changeSeniorAsset_seniorRatio"), 0.80 * 10**27);
     }
 
     function testCloseEpochSubmissionPeriod() public {

--- a/src/lender/test/coordinator-executeEpoch.t.sol
+++ b/src/lender/test/coordinator-executeEpoch.t.sol
@@ -16,7 +16,6 @@
 pragma solidity >=0.5.15 <0.6.0;
 pragma experimental ABIEncoderV2;
 
-
 import "./coordinator-base.t.sol";
 
 contract CoordinatorExecuteEpochTest is CoordinatorTest {
@@ -87,7 +86,7 @@ contract CoordinatorExecuteEpochTest is CoordinatorTest {
         uint shouldNewReserve = safeSub(safeAdd(safeAdd(model_.reserve, input.seniorSupply), input.juniorSupply),
             safeAdd(input.seniorRedeem, input.juniorRedeem));
 
-        uint seniorAsset = coordinator.calcSeniorAssetValue(input.seniorRedeem, input.seniorSupply, safeAdd(model_.seniorDebt, model_.seniorBalance), shouldNewReserve, model_.NAV);
+        uint seniorAsset = assessor.calcSeniorAssetValue(input.seniorRedeem, input.seniorSupply, safeAdd(model_.seniorDebt, model_.seniorBalance), shouldNewReserve, model_.NAV);
 
         // change or orders delta = -2 ether
         uint shouldSeniorAsset = safeSub(safeAdd(model_.seniorDebt, model_.seniorBalance), 2 ether);
@@ -96,7 +95,7 @@ contract CoordinatorExecuteEpochTest is CoordinatorTest {
 
         uint shouldRatio = rdiv(seniorAsset, safeAdd(shouldNewReserve, model_.NAV));
 
-        uint currSeniorRatio = coordinator.calcSeniorRatio(shouldSeniorAsset, model_.NAV, shouldNewReserve);
+        uint currSeniorRatio = assessor.calcSeniorRatio(shouldSeniorAsset, model_.NAV, shouldNewReserve);
 
         assertEq(currSeniorRatio, shouldRatio);
         assertEq(assessor.values_uint("currency_available"), shouldNewReserve);
@@ -110,10 +109,10 @@ contract CoordinatorExecuteEpochTest is CoordinatorTest {
         uint NAV = 1000 ether;
         uint reserve = 1000 ether;
 
-        assertEq(coordinator.calcAssets(NAV, reserve), 2000 ether);
+        assertEq(assessor.calcAssets(NAV, reserve), 2000 ether);
         // ratio 25%
-        assertEq(coordinator.calcSeniorRatio(safeAdd(seniorDebt,seniorBalance), NAV, reserve), 25 * 10**25);
-        assertEq(coordinator.calcSeniorRatio(0, 0, 0), 0);
+        assertEq(assessor.calcSeniorRatio(safeAdd(seniorDebt,seniorBalance), NAV, reserve), 25 * 10**25);
+        assertEq(assessor.calcSeniorRatio(0, 0, 0), 0);
     }
 
     function testCalcSeniorState() public {
@@ -126,7 +125,7 @@ contract CoordinatorExecuteEpochTest is CoordinatorTest {
         uint seniorRedeem = 0;
         uint seniorSupply = 0;
 
-        uint seniorAsset = coordinator.calcSeniorAssetValue(seniorRedeem, seniorSupply, currSeniorAsset, model.reserve, model.NAV);
+        uint seniorAsset = assessor.calcSeniorAssetValue(seniorRedeem, seniorSupply, currSeniorAsset, model.reserve, model.NAV);
 
         assertEq(seniorAsset, 0);
 
@@ -139,7 +138,7 @@ contract CoordinatorExecuteEpochTest is CoordinatorTest {
 
         uint newReserve = coordinator.calcNewReserve(seniorRedeem, 0, seniorSupply, 0);
 
-        seniorAsset = coordinator.calcSeniorAssetValue(seniorRedeem, seniorSupply, currSeniorAsset, newReserve, model.NAV);
+        seniorAsset = assessor.calcSeniorAssetValue(seniorRedeem, seniorSupply, currSeniorAsset, newReserve, model.NAV);
         assertEq(seniorAsset, 210 ether);
 
         // seniorSupply < seniorRedeem
@@ -151,7 +150,7 @@ contract CoordinatorExecuteEpochTest is CoordinatorTest {
 
 
          newReserve = coordinator.calcNewReserve(seniorRedeem, 0, seniorSupply, 0);
-        seniorAsset = coordinator.calcSeniorAssetValue(seniorRedeem, seniorSupply, currSeniorAsset, newReserve, model.NAV);
+        seniorAsset = assessor.calcSeniorAssetValue(seniorRedeem, seniorSupply, currSeniorAsset, newReserve, model.NAV);
         assertEq(seniorAsset, 190 ether);
 
         // seniorSupply < seniorRedeem
@@ -161,7 +160,7 @@ contract CoordinatorExecuteEpochTest is CoordinatorTest {
         seniorSupply = 10 ether;
 
         newReserve = coordinator.calcNewReserve(seniorRedeem, 0, seniorSupply, 0);
-        seniorAsset = coordinator.calcSeniorAssetValue(seniorRedeem, seniorSupply, currSeniorAsset, newReserve, model.NAV);
+        seniorAsset = assessor.calcSeniorAssetValue(seniorRedeem, seniorSupply, currSeniorAsset, newReserve, model.NAV);
         assertEq(seniorAsset, 90 ether);
     }
 }

--- a/src/lender/test/coordinator-executeEpoch.t.sol
+++ b/src/lender/test/coordinator-executeEpoch.t.sol
@@ -103,18 +103,6 @@ contract CoordinatorExecuteEpochTest is CoordinatorTest {
       //  assertEq(assessor.values_uint("updateSenior_seniorDebt"), rmul(model_.NAV, currSeniorRatio));
     }
 
-    function testCalcSeniorRatio() public {
-        uint seniorDebt = 300 ether;
-        uint seniorBalance = 200 ether;
-        uint NAV = 1000 ether;
-        uint reserve = 1000 ether;
-
-        assertEq(assessor.calcAssets(NAV, reserve), 2000 ether);
-        // ratio 25%
-        assertEq(assessor.calcSeniorRatio(safeAdd(seniorDebt,seniorBalance), NAV, reserve), 25 * 10**25);
-        assertEq(assessor.calcSeniorRatio(0, 0, 0), 0);
-    }
-
     function testCalcSeniorState() public {
         LenderModel memory model = getDefaultModel();
         initTestConfig(model);

--- a/src/lender/test/coordinator-improvementScore.t.sol
+++ b/src/lender/test/coordinator-improvementScore.t.sol
@@ -82,7 +82,7 @@ contract CoordinatorImprovementScoreTest is CoordinatorTest, FixedPoint {
         emit log_named_uint("maxSeniorRatio", model.maxSeniorRatio);
         emit log_named_uint("maxSeniorRatio", model.minSeniorRatio);
 
-        uint currentRatio = coordinator.calcSeniorRatio(coordinator.calcSeniorAssetValue(0,0,safeAdd(model.seniorDebt, model.seniorBalance), model.reserve, model.NAV),
+        uint currentRatio = assessor.calcSeniorRatio(assessor.calcSeniorAssetValue(0,0,safeAdd(model.seniorDebt, model.seniorBalance), model.reserve, model.NAV),
             model.NAV, model.reserve);
 
         // check if ratio is broken
@@ -178,7 +178,7 @@ contract CoordinatorImprovementScoreTest is CoordinatorTest, FixedPoint {
         hevm.warp(now + 1 days);
         coordinator.closeEpoch();
 
-        uint currentRatio = coordinator.calcSeniorRatio(coordinator.calcSeniorAssetValue(0,0,safeAdd(model.seniorDebt, model.seniorBalance), model.reserve, model.NAV),
+        uint currentRatio = assessor.calcSeniorRatio(assessor.calcSeniorAssetValue(0,0,safeAdd(model.seniorDebt, model.seniorBalance), model.reserve, model.NAV),
             model.NAV, model.reserve);
 
         // check ratio okay

--- a/src/lender/test/coordinator-submitEpoch.sol
+++ b/src/lender/test/coordinator-submitEpoch.sol
@@ -117,7 +117,7 @@ contract CoordinatorSubmitEpochTest is CoordinatorTest, FixedPoint {
 
     function checkPoolPrecondition(LenderModel memory model, bool currSeniorRatioInRange, bool reserveHealthy) public {
         // check if current ratio is healthy
-        Fixed27 memory currSeniorRatio = Fixed27(coordinator.calcSeniorRatio(coordinator.epochSeniorAsset(),
+        Fixed27 memory currSeniorRatio = Fixed27(assessor.calcSeniorRatio(coordinator.epochSeniorAsset(),
             coordinator.epochNAV(), coordinator.epochReserve()));
 
         assertTrue(coordinator.checkRatioInRange(currSeniorRatio, Fixed27(model.minSeniorRatio), Fixed27(model.maxSeniorRatio)) == currSeniorRatioInRange);

--- a/src/lender/test/definitions.t.sol
+++ b/src/lender/test/definitions.t.sol
@@ -1,0 +1,89 @@
+// Copyright (C) 2020 Centrifuge
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+pragma solidity >=0.5.15 <0.6.0;
+
+import "ds-test/test.sol";
+import "./../definitions.sol";
+
+contract DefinitionTest is Math, DSTest {
+    Definitions def;
+
+    function setUp() public {
+        def = new Definitions();
+    }
+
+    function testCalcSeniorRatio() public {
+        uint seniorDebt = 300 ether;
+        uint seniorBalance = 200 ether;
+        uint NAV = 1000 ether;
+        uint reserve = 1000 ether;
+
+        assertEq(def.calcAssets(NAV, reserve), 2000 ether);
+        // ratio 25%
+        assertEq(def.calcSeniorRatio(safeAdd(seniorDebt,seniorBalance), NAV, reserve), 0.25 * 10**27);
+        assertEq(def.calcSeniorRatio(0, 0, 0), 0);
+    }
+
+    function testCalcSeniorAssetValue() public {
+        uint newReserve = 800 ether;
+        uint nav = 200 ether;
+
+        uint currentSeniorAsset = 700 ether;
+        uint seniorSupply = 120 ether;
+        uint seniorRedeem = 20 ether;
+
+        assertEq(800 ether,
+            def.calcSeniorAssetValue(seniorRedeem, seniorSupply, currentSeniorAsset, newReserve, nav));
+    }
+
+    function testCalcSeniorAssetValueMoreThanAssets() public {
+        uint newReserve = 800 ether;
+        uint nav = 200 ether;
+
+        uint currentSeniorAsset = 700 ether;
+        uint seniorSupply = 500 ether;
+        uint seniorRedeem = 0;
+
+        assertEq(safeAdd(newReserve, nav),
+            def.calcSeniorAssetValue(seniorRedeem, seniorSupply, currentSeniorAsset, newReserve, nav));
+    }
+
+    function testCalcSeniorRatioDef() public {
+        uint reserve = 800 ether;
+        uint nav = 200 ether;
+        uint seniorAssetValue = 600 ether;
+
+        assertEq(def.calcSeniorRatio(seniorAssetValue, nav, reserve), 0.6 * 10**27);
+    }
+
+    function testCalcSeniorRatioOverONE() public {
+        uint reserve = 800 ether;
+        uint nav = 200 ether;
+        uint seniorAssetValue = 1500 ether;
+
+        assertEq(def.calcSeniorRatio(seniorAssetValue, nav, reserve), 1.5 * 10**27);
+    }
+
+    function testCalcSeniorRatioWithOrders() public {
+        uint reserve = 800 ether;
+        uint nav = 200 ether;
+        uint seniorAssetValue = 700 ether;
+        uint seniorSupply = 120 ether;
+        uint seniorRedeem = 20 ether;
+
+        assertEq(def.calcSeniorRatio(seniorRedeem, seniorSupply, seniorAssetValue, nav, reserve), 0.8 * 10**27);
+    }
+}

--- a/src/lender/test/mock/assessor.sol
+++ b/src/lender/test/mock/assessor.sol
@@ -105,9 +105,15 @@ contract AssessorMock is Mock {
 
     function changeSeniorAsset(uint seniorRatio_, uint seniorSupply, uint seniorRedeem) public {
         values_uint["changeSeniorAsset_seniorRatio"] = seniorRatio_;
+        changeSeniorAsset(seniorSupply, seniorRedeem);
+
+    }
+
+    function changeSeniorAsset(uint seniorSupply, uint seniorRedeem) public {
         values_uint["changeSeniorAsset_seniorSupply"] = seniorSupply;
         values_uint["changeSeniorAsset_seniorRedeem"] = seniorRedeem;
     }
+
 
     function repaymentUpdate(uint currencyAmount) public  {
         values_uint["repaymentUpdate_currencyAmount"] = currencyAmount;

--- a/src/lender/test/mock/clerk.sol
+++ b/src/lender/test/mock/clerk.sol
@@ -1,0 +1,29 @@
+// Copyright (C) 2020 Centrifuge
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+pragma solidity >=0.5.15 <0.6.0;
+import "ds-test/test.sol";
+
+import "../../../test/mock/mock.sol";
+
+contract ClerkMock is Mock {
+    function remainingCredit() external view returns (uint) {
+        return values_return["remainingCredit"];
+    }
+    function juniorStake() external view returns (uint) {
+        return values_return["juniorStake"];
+    }
+    function remainingCreditCollateral() external view returns (uint) {
+        return values_return["remainingCreditCollateral"];
+    }
+}

--- a/src/test/system/base_system.sol
+++ b/src/test/system/base_system.sol
@@ -197,7 +197,9 @@ contract BaseSystemTest is TestSetup, Math, DSTest {
 
         tokenId = collateralNFT.issue(borrower_);
         loan = setupLoan(tokenId, collateralNFT_, nftPrice, riskGroup, maturityDate);
+        emit log_named_uint("seniorDebtXXX", assessor.seniorDebt());
         borrow(loan, tokenId, borrowAmount, lenderFundingRequired);
+        emit log_named_uint("seniorDebtXX", assessor.seniorDebt());
         return (loan, tokenId);
     }
 
@@ -238,9 +240,13 @@ contract BaseSystemTest is TestSetup, Math, DSTest {
         borrower.approveNFT(collateralNFT, address(shelf));
         if (fundLenderRequired) {
             fundLender(borrowAmount);
+            emit log_named_uint("xxxx", assessor.seniorDebt());
         }
+        emit log_named_uint("xxx", assessor.seniorDebt());
         borrower.borrowAction(loan, borrowAmount);
+        emit log_named_uint("fdf", assessor.seniorDebt());
         checkAfterBorrow(tokenId, borrowAmount);
+        emit log_named_uint("aaa", assessor.seniorDebt());
     }
 
     function defaultCollateral() public pure returns(uint nftPrice_, uint riskGroup_) {

--- a/src/test/system/lender/lender_scenarios.t.sol
+++ b/src/test/system/lender/lender_scenarios.t.sol
@@ -504,7 +504,7 @@ contract LenderSystemTest is BaseSystemTest, BaseTypes, Interest {
         uint borrowAmount = 100 ether;
         uint nftPrice = 200 ether;
         uint maturityDate = 5 days;
-        (uint loan, ) = setupOngoingLoan(nftPrice, borrowAmount, false, nftFeed.uniqueDayTimestamp(now) +maturityDate);
+        setupOngoingLoan(nftPrice, borrowAmount, false, nftFeed.uniqueDayTimestamp(now) +maturityDate);
 
         hevm.warp(now + 1 days);
 


### PR DESCRIPTION
**Summary**
In preparation for the MKR adapter I refactored the coordinator and assessor to make the integration more smoothly.

**Details**
- moved all pure functions from the coordinator and assessor to a own contract (definitions)
   - assessor uses inheritance with the definition contract
- added a pure validate function to coordinator
- fix reBalancingBug not lose track of expectedSeniorAsset value
- added ratio < ONE check to reBalanceMethod
- changeSeniorAsset in assessor doesn't require a ratio anymore
  - the ratio is calculated based on the recent nav and reserve
- fixed some existing compiler warnings