### PR TITLE
feat: integrated lending adapter into reserve

### DIFF
--- a/src/lender/adapters/mkr/clerk.sol
+++ b/src/lender/adapters/mkr/clerk.sol
@@ -5,7 +5,7 @@ import "tinlake-math/math.sol";
 
 interface ManagerLike {
     // collateral debt
-    function cdptab() external returns(uint);
+    function cdptab() external view returns(uint);
     // put collateral into cdp
     function join(uint amountDROP) external;
     // draw DAi from cdp
@@ -123,7 +123,7 @@ contract Clerk is Auth, Math {
         if (what == "buffer") {
             matBuffer = value;
         }
-    } 
+    }
 
     function remainingCredit() public returns (uint) {
         if (creditline < mgr.cdptab()) {
@@ -263,5 +263,9 @@ contract Clerk is Auth, Math {
 
     function changeOwnerMgr(address usr) public auth {
         mgr.setOwner(usr);
+    }
+
+    function debt() public view returns(uint) {
+        return mgr.cdptab();
     }
 }

--- a/src/lender/test/mock/clerk.sol
+++ b/src/lender/test/mock/clerk.sol
@@ -26,4 +26,9 @@ contract ClerkMock is Mock {
     function remainingCreditCollateral() external view returns (uint) {
         return values_return["remainingCreditCollateral"];
     }
+
+    function debt() external view returns(uint) {
+        return values_return["debt"];
+    }
 }
+

--- a/src/lender/test/mock/reserve.sol
+++ b/src/lender/test/mock/reserve.sol
@@ -43,11 +43,21 @@ contract ReserveMock is Mock, Auth {
         return values_return["balance"];
     }
 
+    function hardDeposit(uint amount) public {
+        values_uint["deposit_amount"] = amount;
+        currency.transferFrom(msg.sender, address(this), amount);
+    }
+
+    function hardPayout(uint amount) public {
+        values_uint["deposit_amount"] = amount;
+        currency.transferFrom(address(this), msg.sender, amount);
+    }
+
     function deposit(uint amount) public {
         values_uint["deposit_amount"] = amount;
         currency.transferFrom(msg.sender, address(this), amount);
     }
-    
+
     function payout(uint amount) public {
         values_uint["deposit_amount"] = amount;
         currency.transferFrom(address(this), msg.sender, amount);

--- a/src/lender/test/reserve.t.sol
+++ b/src/lender/test/reserve.t.sol
@@ -22,13 +22,40 @@ import "../../test/simple/token.sol";
 import "./../reserve.sol";
 import "./mock/assessor.sol";
 import "../../borrower/test/mock/shelf.sol";
+import "./mock/clerk.sol";
+
+interface ReserveLike {
+    function hardDeposit(uint currencyAmount) external;
+    function hardPayout(uint currencyAmount) external;
+}
+
+contract LendingAdapterMock is ClerkMock {
+    ReserveLike reserve;
+    ERC20Like currency;
+
+    constructor(address currency_, address reserve_) public    {
+        reserve = ReserveLike(reserve_);
+        currency = ERC20Like(currency_);
+    }
+
+    function draw(uint amount) public {
+        currency.mint(address(this), amount);
+        currency.approve(address(reserve), amount);
+        reserve.hardDeposit(amount);
+    }
+
+    function wipe(uint amount) public {
+        reserve.hardPayout(amount);
+    }
+}
 
 contract ReserveTest is DSTest, Math {
-
     SimpleToken currency;
     Reserve reserve;
     ShelfMock shelf;
     AssessorMock assessor;
+
+    LendingAdapterMock lending;
 
     address shelf_;
     address reserve_;
@@ -54,6 +81,12 @@ contract ReserveTest is DSTest, Math {
 
         reserve.depend("shelf", shelf_);
         reserve.depend("assessor", assessor_);
+    }
+
+    function setUpLendingAdapter() public {
+        lending = new LendingAdapterMock(currency_, reserve_);
+        reserve.depend("lending", address(lending));
+        reserve.rely(address(lending));
     }
 
     function fundReserve(uint amount) public {
@@ -197,5 +230,92 @@ contract ReserveTest is DSTest, Math {
         assertEq(reserve.totalBalance(), 40 ether);
         assertEq(currency.balanceOf(reserve_), 40 ether);
         assertEq(currency.balanceOf(self), 60 ether);
+    }
+
+    function testDrawFromZeroBalance() public {
+        setUpLendingAdapter();
+        uint remainingCredit = 100 ether;
+        lending.setReturn("remainingCredit", remainingCredit);
+        uint amount = 10 ether;
+        reserve.payout(amount);
+        assertEq(currency.balanceOf(self), amount);
+    }
+
+    function testAdditionalDraw() public {
+        setUpLendingAdapter();
+        uint amount = 100 ether;
+        fundReserve(amount);
+        uint remainingCredit = 100 ether;
+        lending.setReturn("remainingCredit", remainingCredit);
+        uint payoutAmount = 150 ether;
+        reserve.payout(payoutAmount);
+        assertEq(currency.balanceOf(self), payoutAmount);
+    }
+
+    function testAdditionalDrawMax() public {
+        setUpLendingAdapter();
+        uint amount = 100 ether;
+        fundReserve(amount);
+
+        uint remainingCredit = 100 ether;
+        lending.setReturn("remainingCredit", remainingCredit);
+
+        uint payoutAmount = 200 ether;
+        reserve.payout(payoutAmount);
+        assertEq(currency.balanceOf(self), payoutAmount);
+    }
+    function testFailDraw() public {
+        setUpLendingAdapter();
+        uint amount = 100 ether;
+        fundReserve(amount);
+
+        uint remainingCredit = 100 ether;
+        lending.setReturn("remainingCredit", remainingCredit);
+
+        uint payoutAmount = 201 ether;
+        reserve.payout(payoutAmount);
+        assertEq(currency.balanceOf(self), payoutAmount);
+    }
+
+    function testFailDrawFromZeroBalance() public {
+        setUpLendingAdapter();
+
+        uint remainingCredit = 100 ether;
+        lending.setReturn("remainingCredit", remainingCredit);
+
+        uint payoutAmount = 101 ether;
+        reserve.payout(payoutAmount);
+        assertEq(currency.balanceOf(self), payoutAmount);
+    }
+
+    function testWipe() public {
+        setUpLendingAdapter();
+        uint debt = 70 ether;
+        lending.setReturn("debt", debt);
+
+        uint amount = 100 ether;
+        fundReserve(amount);
+        assertEq(currency.balanceOf(reserve_), amount-debt);
+    }
+
+    function testWipeHighDebt() public {
+        setUpLendingAdapter();
+        uint debt = 700 ether;
+        lending.setReturn("debt", debt);
+
+        uint amount = 100 ether;
+        fundReserve(amount);
+        assertEq(currency.balanceOf(reserve_), 0);
+        assertEq(currency.balanceOf(address(lending)), amount);
+    }
+
+    function testNoWipeZeroDebt() public {
+        setUpLendingAdapter();
+        uint debt = 0;
+        lending.setReturn("debt", debt);
+        uint amount = 100 ether;
+        fundReserve(amount);
+        assertEq(currency.balanceOf(reserve_), amount);
+
     }
 }


### PR DESCRIPTION
## Summary

The currency in the reserve is automatically used to repay/reduce lender adapter debt. The deposit method automatically calls clerk.wipe. If currency is requested the reserve uses the adapter to request additional currency.(clerk.draw)

## Changes
**Reserve Contract**
- lending adapter can be optional set in the reserve contract 
-

**Clerk Contract**
- changed reserve call to hardDeposit and hardPayout
  - otherwise we would have the following problem
      - tranche contract calls payout
      - additional currency is required and clerk.draw call happens
      - draw calls internally deposit
      - deposit would use the receive currency to repay adapter debt
      - the just received currency from adapter would be immediately used to repay back to the adapter 