### PR TITLE
feat: added creditBuffer to totalBalance in assessor + drawOnDemand tests

### DIFF
--- a/src/fixed_point.sol
+++ b/src/fixed_point.sol
@@ -14,7 +14,9 @@
 
 pragma solidity >=0.5.15 <0.6.0;
 
-contract FixedPoint {
+import "ds-test/test.sol";
+
+contract FixedPoint is DSTest {
     struct Fixed27 {
         uint value;
     }

--- a/src/fixed_point.sol
+++ b/src/fixed_point.sol
@@ -14,9 +14,7 @@
 
 pragma solidity >=0.5.15 <0.6.0;
 
-import "ds-test/test.sol";
-
-contract FixedPoint is DSTest {
+contract FixedPoint {
     struct Fixed27 {
         uint value;
     }

--- a/src/lender/adapters/mkr/assessor.sol
+++ b/src/lender/adapters/mkr/assessor.sol
@@ -104,7 +104,8 @@ contract MKRAssessor is Assessor {
         uint debt = clerk.debt();
         // over the time the remainingCredit will decrease because of the accumulated debt interest
         // therefore a buffer is reduced from the  remainingCredit to prevent the usage of currency which is not available
-        uint debtIncrease = safeSub(chargeInterest(debt, clerk.stabilityFee(), safeAdd(block.timestamp, creditBufferTime)), debt);
+        uint debtIncrease = safeSub(rmul(rpow(clerk.stabilityFee(),
+            safeSub(safeAdd(block.timestamp, creditBufferTime), block.timestamp), ONE), debt), debt);
 
         if(clerk.remainingCredit() > debtIncrease) {
             return safeAdd(reserve.totalBalance(), safeSub(clerk.remainingCredit(), debtIncrease));

--- a/src/lender/adapters/mkr/assessor.sol
+++ b/src/lender/adapters/mkr/assessor.sol
@@ -20,10 +20,22 @@ interface ClerkLike {
     function remainingCredit() external view returns (uint);
     function juniorStake() external view returns (uint);
     function remainingOvercollCredit() external view returns (uint);
+    function stabilityFee() external view returns(uint);
+    function debt() external view returns(uint);
 }
 
 contract MKRAssessor is Assessor {
     ClerkLike public clerk;
+
+    uint public creditBufferTime = 10 days;
+
+    function file(bytes32 name, uint value) public auth {
+        if(name == "creditBufferTime") {
+            creditBufferTime = value;
+            return;
+        }
+        super.file(name, value);
+    }
 
     function depend(bytes32 contractName, address addr) public auth {
         if (contractName == "clerk") {
@@ -89,7 +101,16 @@ contract MKRAssessor is Assessor {
     }
 
     function totalBalance() public view returns(uint) {
-        return safeAdd(reserve.totalBalance(), clerk.remainingCredit());
+        uint debt = clerk.debt();
+        // over the time the remainingCredit will decrease because of the accumulated debt interest
+        // therefore a buffer is reduced from the  remainingCredit to prevent the usage of currency which is not available
+        uint debtIncrease = safeSub(chargeInterest(debt, clerk.stabilityFee(), safeAdd(block.timestamp, creditBufferTime)), debt);
+
+        if(clerk.remainingCredit() > debtIncrease) {
+            return safeAdd(reserve.totalBalance(), safeSub(clerk.remainingCredit(), debtIncrease));
+        }
+
+        return reserve.totalBalance();
     }
 
     // returns the current NAV
@@ -100,5 +121,10 @@ contract MKRAssessor is Assessor {
     // returns the approximated NAV for gas-performance reasons
     function getNAV() public view returns(uint) {
         return navFeed.approximatedNAV();
+    }
+
+    // changes the total amount available for borrowing loans
+    function changeBorrowAmountEpoch(uint currencyAmount) public auth {
+        reserve.file("currencyAvailable", currencyAmount);
     }
 }

--- a/src/lender/adapters/mkr/assessor.sol
+++ b/src/lender/adapters/mkr/assessor.sol
@@ -105,7 +105,7 @@ contract MKRAssessor is Assessor {
         // over the time the remainingCredit will decrease because of the accumulated debt interest
         // therefore a buffer is reduced from the  remainingCredit to prevent the usage of currency which is not available
         uint debtIncrease = safeSub(rmul(rpow(clerk.stabilityFee(),
-            safeSub(safeAdd(block.timestamp, creditBufferTime), block.timestamp), ONE), debt), debt);
+            creditBufferTime, ONE), debt), debt);
 
         if(clerk.remainingCredit() > debtIncrease) {
             return safeAdd(reserve.totalBalance(), safeSub(clerk.remainingCredit(), debtIncrease));

--- a/src/lender/adapters/mkr/clerk.sol
+++ b/src/lender/adapters/mkr/clerk.sol
@@ -66,7 +66,7 @@ interface CoordinatorLike {
     function validatePoolConstraints(uint reserve_, uint seniorAsset, uint nav_) external returns(int);
     function calcSeniorAssetValue(uint seniorRedeem, uint seniorSupply, uint currSeniorAsset, uint reserve_, uint nav_) external returns(uint);
     function calcSeniorRatio(uint seniorAsset, uint NAV, uint reserve_) external returns(uint);
-    function submissionPeriod() external returns(bool);
+    function submissionPeriod() external view returns(bool);
 }
 
 interface ReserveLike {
@@ -110,7 +110,11 @@ contract Clerk is Auth, Math {
     uint matBuffer = 0.01 * 10**27;
 
     // adapter functions can only be active if the tinlake pool is currently not in epoch closing/submissions/execution state
-    modifier active() { require((coordinator.submissionPeriod() == false), "epoch-closing"); _; }
+    modifier active() { require(activated(), "epoch-closing"); _; }
+
+    function activated() public view returns(bool) {
+        return coordinator.submissionPeriod() == false;
+    }
 
     constructor(address dai_, address collateral_) public {
         wards[msg.sender] = 1;

--- a/src/lender/adapters/mkr/clerk.sol
+++ b/src/lender/adapters/mkr/clerk.sol
@@ -29,23 +29,24 @@ interface ManagerLike {
     // remove collateral from cdp
     function exit(address usr, uint amountDROP) external;
     // collateral ID
-    function ilk() external returns(bytes32);
+    function ilk() external view returns(bytes32);
     // indicates if soft-liquidation was activated
-    function safe() external returns(bool);
+    function safe() external view returns(bool);
     // indicates if hard-liquidation was activated
-    function glad() external returns(bool);
+    function glad() external view returns(bool);
     // indicates if global settlement was triggered
-    function live() external returns(bool);
+    function live() external view returns(bool);
     // auth functions
     function setOwner(address newOwner) external;
 }
 
 interface VatLike {
     function urns(bytes32, address) external returns (uint,uint);
+    function ilks(bytes32) external view returns(uint, uint, uint, uint, uint);
 }
 
 interface SpotterLike {
-    function ilks(bytes32) external returns(address, uint256);
+    function ilks(bytes32) external view returns(address, uint256);
 }
 
 interface AssessorLike {
@@ -331,5 +332,10 @@ contract Clerk is Auth, Math {
 
     function debt() public view returns(uint) {
         return mgr.cdptab();
+    }
+
+    function stabilityFee() public view returns(uint) {
+        (, uint rate, , ,) = vat.ilks(mgr.ilk());
+        return rate;
     }
 }

--- a/src/lender/adapters/mkr/deployer.sol
+++ b/src/lender/adapters/mkr/deployer.sol
@@ -72,6 +72,10 @@ contract MKRLenderDeployer is LenderDeployer {
         AuthLike(seniorTranche).rely(clerk);
         AuthLike(reserve).rely(clerk);
         AuthLike(assessor).rely(clerk);
+
+        // reserve can draw and wipe on clerk
+        AuthLike(clerk).rely(reserve);
+
         // allow clerk to hold seniorToken
         MemberlistLike(seniorMemberlist).updateMember(clerk, uint(-1));
         MemberlistLike(seniorMemberlist).updateMember(mkrMgr, uint(-1));

--- a/src/lender/adapters/mkr/test/clerk.t.sol
+++ b/src/lender/adapters/mkr/test/clerk.t.sol
@@ -104,7 +104,6 @@ contract ClerkTest is Math, DSTest {
         uint creditlineInit = clerk.creditline();
         uint remainingCreditInit = clerk.remainingCredit();
         uint validateCallsInit = coordinator.calls("validatePoolConstraints");
-        uint submissionPeriodCallsInit = coordinator.calls("submissionPeriod");
         uint overcollAmount = clerk.calcOvercollAmount(amountDAI);
         uint creditProtection = safeSub(overcollAmount, amountDAI);
 
@@ -116,7 +115,6 @@ contract ClerkTest is Math, DSTest {
         // assert remainingCreditLine was also increased
         assertEq(clerk.remainingCredit(), safeAdd(remainingCreditInit, amountDAI));
         // assert call count coordinator & function arguments
-        assertEq(coordinator.calls("submissionPeriod"), safeAdd(submissionPeriodCallsInit, 1));
         assertEq(coordinator.values_uint("reserve"), overcollAmount-creditProtection);
         assertEq(coordinator.values_uint("seniorAsset"), overcollAmount);
     }
@@ -228,7 +226,6 @@ contract ClerkTest is Math, DSTest {
         uint creditlineInit = clerk.creditline();
         uint remainingCreditInit = clerk.remainingCredit();
         uint validateCallsInit = coordinator.calls("validatePoolConstraints");
-        uint submissionPeriodCallsInit = coordinator.calls("submissionPeriod");
         uint overcollAmount = clerk.calcOvercollAmount(amountDAI);
         uint creditProtection = safeSub(overcollAmount, amountDAI);
 
@@ -244,7 +241,7 @@ contract ClerkTest is Math, DSTest {
         // assert remainingCreditLine was also decreased
         assertEq(clerk.remainingCredit(), safeSub(remainingCreditInit, amountDAI));
         // assert call count coordinator & function arguments
-        assertEq(coordinator.calls("submissionPeriod"), safeAdd(submissionPeriodCallsInit, 1));
+
         assertEq(coordinator.values_uint("reserve"), reserve - overcollAmount + creditProtection);
         assertEq(coordinator.values_uint("seniorAsset"), seniorBalance -overcollAmount);
     }

--- a/src/lender/adapters/mkr/test/clerk.t.sol
+++ b/src/lender/adapters/mkr/test/clerk.t.sol
@@ -236,6 +236,7 @@ contract ClerkTest is Math, DSTest {
         uint seniorBalance = 800 ether;
         assessor.setReturn("balance", reserve);
         assessor.setReturn("seniorBalance", seniorBalance);
+        assessor.setReturn("borrowAmountEpoch", reserve);
         // raise creditLine
         clerk.sink(amountDAI);
         // assert creditLine was decreased

--- a/src/lender/adapters/mkr/test/mock/mgr.sol
+++ b/src/lender/adapters/mkr/test/mock/mgr.sol
@@ -59,15 +59,15 @@ contract ManagerMock is Mock {
         values_uint["tab"] = safeSub(values_uint["tab"], amountDAI);
     }
 
-    function safe() external returns(bool) {
+    function safe() external view returns(bool) {
         return values_bool_return["safe"];
     }
 
-    function glad() external returns(bool) {
+    function glad() external view returns(bool) {
         return values_bool_return["glad"];
     }
 
-    function live() external returns(bool) {
+    function live() external view returns(bool) {
         return values_bool_return["live"];
     }
 

--- a/src/lender/adapters/mkr/test/mock/spotter.sol
+++ b/src/lender/adapters/mkr/test/mock/spotter.sol
@@ -17,7 +17,7 @@ import "ds-test/test.sol";
 import "../../../../../test/mock/mock.sol";
 
 contract SpotterMock is Mock {
-    function ilks(bytes32 id) external returns(address, uint256) {
+    function ilks(bytes32 id) external view returns(address, uint256) {
         return (values_address_return["pip"], values_return["mat"]);
     }
 }

--- a/src/lender/adapters/mkr/test/mock/vat.sol
+++ b/src/lender/adapters/mkr/test/mock/vat.sol
@@ -17,7 +17,7 @@ import "ds-test/test.sol";
 import "../../../../../test/mock/mock.sol";
 
 contract VatMock is Mock {
-    function urns(bytes32, address) external returns (uint, uint) {
+    function urns(bytes32, address) external view returns (uint, uint) {
         return (values_return["ink"], 0);
     }
 

--- a/src/lender/assessor.sol
+++ b/src/lender/assessor.sol
@@ -31,6 +31,7 @@ interface TrancheLike {
 interface ReserveLike {
     function totalBalance() external view returns(uint);
     function file(bytes32 what, uint currencyAmount) external;
+    function currencyAvailable() external view returns(uint);
 }
 
 contract Assessor is Definitions, Auth, Interest {
@@ -249,7 +250,11 @@ contract Assessor is Definitions, Auth, Interest {
     }
 
     // changes the total amount available for borrowing loans
-    function changeReserveAvailable(uint currencyAmount) public auth {
+    function changeBorrowAmountEpoch(uint currencyAmount) public auth {
         reserve.file("currencyAvailable", currencyAmount);
+    }
+
+    function borrowAmountEpoch() public view returns(uint) {
+        return reserve.currencyAvailable();
     }
 }

--- a/src/lender/coordinator.sol
+++ b/src/lender/coordinator.sol
@@ -49,10 +49,8 @@ contract AssessorLike is FixedPoint {
     function seniorRatioBounds() external view returns(Fixed27 memory minSeniorRatio, Fixed27 memory maxSeniorRatio);
 
     function totalBalance() external returns(uint);
-
-
     // change state
-    function changeReserveAvailable(uint currencyAmount) public;
+    function changeBorrowAmountEpoch(uint currencyAmount) public;
     function changeSeniorAsset(uint seniorSupply, uint seniorRedeem) external;
     function changeSeniorAsset(uint seniorRatio, uint seniorSupply, uint seniorRedeem) external;
 }
@@ -187,7 +185,7 @@ contract EpochCoordinator is Auth, Math, FixedPoint  {
         lastEpochClosed = block.timestamp;
         currentEpoch = currentEpoch + 1;
         reserve.balance();
-        assessor.changeReserveAvailable(0);
+        assessor.changeBorrowAmountEpoch(0);
 
         (uint orderJuniorSupply, uint orderJuniorRedeem) = juniorTranche.closeEpoch();
         (uint orderSeniorSupply, uint orderSeniorRedeem) = seniorTranche.closeEpoch();
@@ -586,7 +584,7 @@ contract EpochCoordinator is Auth, Math, FixedPoint  {
         // assessor performs senior debt reBalancing according to new ratio
         assessor.changeSeniorAsset(seniorSupply, seniorRedeem);
         // the new reserve after this epoch can be used for new loans
-        assessor.changeReserveAvailable(newReserve);
+        assessor.changeBorrowAmountEpoch(newReserve);
         // reset state for next epochs
         lastEpochExecuted = epochID;
         submissionPeriod = false;

--- a/src/lender/coordinator.sol
+++ b/src/lender/coordinator.sol
@@ -567,6 +567,7 @@ contract EpochCoordinator is Auth, Math, FixedPoint  {
         uint seniorSupply, uint juniorSupply) internal {
 
         uint epochID = safeAdd(lastEpochExecuted, 1);
+        submissionPeriod = false;
 
         // tranche epochUpdates triggers currency transfers from/to reserve
         // an mint/burn tokens
@@ -587,7 +588,6 @@ contract EpochCoordinator is Auth, Math, FixedPoint  {
         assessor.changeBorrowAmountEpoch(newReserve);
         // reset state for next epochs
         lastEpochExecuted = epochID;
-        submissionPeriod = false;
         minChallengePeriodEnd = 0;
         bestSubScore = 0;
         gotFullValidSolution = false;

--- a/src/lender/reserve.sol
+++ b/src/lender/reserve.sol
@@ -26,6 +26,7 @@ interface LendingAdapter {
     function draw(uint amount) external;
     function wipe(uint amount) external;
     function debt() external view returns(uint);
+    function activated() external view returns(bool);
 }
 
 // The reserve keeps track of the currency and the bookkeeping
@@ -102,7 +103,7 @@ contract Reserve is Math, Auth {
 
     function _deposit(address usr, uint currencyAmount) internal {
         _depositAction(usr, currencyAmount);
-        if(address(lending) != address(0) && lending.debt() > 0) {
+        if(address(lending) != address(0) && lending.debt() > 0 && lending.activated()) {
             uint wipeAmount = lending.debt();
             uint available = currency.balanceOf(pot);
             if(available < wipeAmount) {
@@ -124,7 +125,7 @@ contract Reserve is Math, Auth {
 
     function _payout(address usr, uint currencyAmount)  internal {
         uint reserveBalance = currency.balanceOf(pot);
-        if (currencyAmount > reserveBalance && address(lending) != address(0)) {
+        if (currencyAmount > reserveBalance && address(lending) != address(0) && lending.activated()) {
             uint drawAmount = safeSub(currencyAmount, reserveBalance);
             uint left = lending.remainingCredit();
             if(drawAmount > left) {

--- a/src/lender/reserve.sol
+++ b/src/lender/reserve.sol
@@ -28,9 +28,11 @@ interface LendingAdapter {
     function debt() external view returns(uint);
 }
 
+import "ds-test/test.sol";
+
 // The reserve keeps track of the currency and the bookkeeping
 // of the total balance
-contract Reserve is Math, Auth {
+contract Reserve is Math, Auth, DSTest {
     ERC20Like public currency;
     ShelfLike public shelf;
     AssessorLike public assessor;
@@ -123,13 +125,16 @@ contract Reserve is Math, Auth {
     }
 
     function _payout(address usr, uint currencyAmount)  internal {
+        emit log_named_uint("sdfsdf", 3);
         uint reserveBalance = currency.balanceOf(pot);
         if (currencyAmount > reserveBalance && address(lending) != address(0)) {
+            emit log_named_uint("fuu", 1);
             uint drawAmount = safeSub(currencyAmount, reserveBalance);
             uint left = lending.remainingCredit();
             if(drawAmount > left) {
                 drawAmount = left;
             }
+            emit log_named_uint("fuu", 2);
             lending.draw(drawAmount);
         }
 
@@ -141,8 +146,9 @@ contract Reserve is Math, Auth {
     function balance() public {
         (bool requestWant, uint256 currencyAmount) = shelf.balanceRequest();
         if (requestWant) {
+        //    uint a = safeAdd(currencyAvailable, lending.remainingCredit());
             require(
-                currencyAvailable >= currencyAmount,
+                currencyAvailable  >= currencyAmount,
                 "not-enough-currency-reserve"
             );
 

--- a/src/lender/reserve.sol
+++ b/src/lender/reserve.sol
@@ -28,11 +28,9 @@ interface LendingAdapter {
     function debt() external view returns(uint);
 }
 
-import "ds-test/test.sol";
-
 // The reserve keeps track of the currency and the bookkeeping
 // of the total balance
-contract Reserve is Math, Auth, DSTest {
+contract Reserve is Math, Auth {
     ERC20Like public currency;
     ShelfLike public shelf;
     AssessorLike public assessor;
@@ -125,16 +123,14 @@ contract Reserve is Math, Auth, DSTest {
     }
 
     function _payout(address usr, uint currencyAmount)  internal {
-        emit log_named_uint("sdfsdf", 3);
         uint reserveBalance = currency.balanceOf(pot);
         if (currencyAmount > reserveBalance && address(lending) != address(0)) {
-            emit log_named_uint("fuu", 1);
             uint drawAmount = safeSub(currencyAmount, reserveBalance);
             uint left = lending.remainingCredit();
             if(drawAmount > left) {
                 drawAmount = left;
             }
-            emit log_named_uint("fuu", 2);
+
             lending.draw(drawAmount);
         }
 
@@ -146,7 +142,6 @@ contract Reserve is Math, Auth, DSTest {
     function balance() public {
         (bool requestWant, uint256 currencyAmount) = shelf.balanceRequest();
         if (requestWant) {
-        //    uint a = safeAdd(currencyAvailable, lending.remainingCredit());
             require(
                 currencyAvailable  >= currencyAmount,
                 "not-enough-currency-reserve"

--- a/src/lender/test/assessor.t.sol
+++ b/src/lender/test/assessor.t.sol
@@ -395,10 +395,10 @@ contract AssessorTest is DSTest, Math {
         assertEq(assessor.totalBalance(), totalBalance);
     }
 
-    function testChangeReserveAvailable() public {
+    function testchangeBorrowAmountEpoch() public {
         uint amount = 100 ether;
-        assertEq(reserveMock.values_uint("currency_available"), 0);
-        assessor.changeReserveAvailable(amount);
-        assertEq(reserveMock.values_uint("currency_available"), amount);
+        assertEq(reserveMock.values_uint("borrow_amount"), 0);
+        assessor.changeBorrowAmountEpoch(amount);
+        assertEq(reserveMock.values_uint("borrow_amount"), amount);
     }
 }

--- a/src/lender/test/coordinator-closeEpoch.t.sol
+++ b/src/lender/test/coordinator-closeEpoch.t.sol
@@ -22,7 +22,7 @@ contract CoordinatorCloseEpochTest is CoordinatorTest {
     function setUp() public {
         super.setUp();
         // set max available currency to 1 to check if it was set to 0 on close
-        assessor.changeReserveAvailable(1);
+        assessor.changeBorrowAmountEpoch(1);
     }
 
     function testMinimumEpochTime() public {
@@ -110,7 +110,7 @@ contract CoordinatorCloseEpochTest is CoordinatorTest {
         coordinator.closeEpoch();
         assertEq(coordinator.lastEpochExecuted(), 0);
         assertTrue(coordinator.submissionPeriod() == true);
-        assertEq(assessor.values_uint("currency_available"), 0);
+        assertEq(assessor.values_uint("borrow_amount"), 0);
     }
 }
 

--- a/src/lender/test/coordinator-executeEpoch.t.sol
+++ b/src/lender/test/coordinator-executeEpoch.t.sol
@@ -98,7 +98,7 @@ contract CoordinatorExecuteEpochTest is CoordinatorTest {
         uint currSeniorRatio = assessor.calcSeniorRatio(shouldSeniorAsset, model_.NAV, shouldNewReserve);
 
         assertEq(currSeniorRatio, shouldRatio);
-        assertEq(assessor.values_uint("currency_available"), shouldNewReserve);
+        assertEq(assessor.values_uint("borrow_amount"), shouldNewReserve);
 
       //  assertEq(assessor.values_uint("updateSenior_seniorDebt"), rmul(model_.NAV, currSeniorRatio));
     }

--- a/src/lender/test/mock/assessor.sol
+++ b/src/lender/test/mock/assessor.sol
@@ -151,8 +151,12 @@ contract AssessorMock is Mock {
         return call("balance");
     }
 
-    function changeReserveAvailable(uint currencyAmount) public {
-        values_uint["currency_available"] = currencyAmount;
+    function changeBorrowAmountEpoch(uint currencyAmount) public {
+        values_uint["borrow_amount"] = currencyAmount;
+    }
+
+    function borrowAmountEpoch() public view returns(uint) {
+        return values_return["borrowAmountEpoch"];
     }
 
     function currentNAV() public view returns(uint) {

--- a/src/lender/test/mock/clerk.sol
+++ b/src/lender/test/mock/clerk.sol
@@ -30,5 +30,9 @@ contract ClerkMock is Mock {
     function debt() external view returns(uint) {
         return values_return["debt"];
     }
+
+    function stabilityFee() external view returns(uint) {
+        return values_return["stabilityFee"];
+    }
 }
 

--- a/src/lender/test/mock/clerk.sol
+++ b/src/lender/test/mock/clerk.sol
@@ -34,5 +34,9 @@ contract ClerkMock is Mock {
     function stabilityFee() external view returns(uint) {
         return values_return["stabilityFee"];
     }
+
+    function activated() public view returns(bool) {
+        return values_bool_return["activated"];
+    }
 }
 

--- a/src/lender/test/mock/coordinator.sol
+++ b/src/lender/test/mock/coordinator.sol
@@ -16,8 +16,7 @@ pragma solidity >=0.5.15 <0.6.0;
 import "../../../test/mock/mock.sol";
 
 contract CoordinatorMock is Mock {
-    function submissionPeriod() public returns(bool) {
-        calls["submissionPeriod"]++;
+    function submissionPeriod() public view returns(bool) {
         return values_bool_return["submissionPeriod"];
     }
 

--- a/src/lender/test/mock/reserve.sol
+++ b/src/lender/test/mock/reserve.sol
@@ -32,7 +32,7 @@ contract ReserveMock is Mock, Auth {
     }
 
     function file(bytes32 , uint currencyAmount) public {
-        values_uint["currency_available"] = currencyAmount;
+        values_uint["borrow_amount"] = currencyAmount;
     }
 
     function balance() public returns (uint) {

--- a/src/lender/test/reserve.t.sol
+++ b/src/lender/test/reserve.t.sol
@@ -87,6 +87,7 @@ contract ReserveTest is DSTest, Math {
         lending = new LendingAdapterMock(currency_, reserve_);
         reserve.depend("lending", address(lending));
         reserve.rely(address(lending));
+        lending.setReturn("activated", true);
     }
 
     function fundReserve(uint amount) public {

--- a/src/test/simple/mkr.sol
+++ b/src/test/simple/mkr.sol
@@ -21,14 +21,12 @@ contract SimpleMkr is Math {
     uint debt;
 
     bytes32 public ilk;
-    uint mat;
 
     bool safeFlag;
 
-    constructor(uint stabilityFee_, bytes32 ilk_, uint mat_) public {
+    constructor(uint stabilityFee_, bytes32 ilk_) public {
         stabilityFee = stabilityFee_;
         ilk = ilk_;
-        mat = mat_;
         safeFlag = true;
     }
 
@@ -76,8 +74,12 @@ contract SimpleMkr is Math {
         return (drop.balanceOf(address(this)), 0);
     }
 
-    // Spotter Like
-    function ilks(bytes32) external returns(address, uint256) {
-        return (address(drop), mat);
+    function ilks(bytes32) external returns(uint, uint, uint, uint, uint)  {
+        return(0, stabilityFee, 0, 0, 0);
     }
+
+//    // Spotter Like
+//    function ilks(bytes32) external returns(address, uint256) {
+//        return (address(drop), mat);
+//    }
 }

--- a/src/test/system/assertions.sol
+++ b/src/test/system/assertions.sol
@@ -30,6 +30,13 @@ contract Assertions is DSTest, Math {
         assertEq(a/precision, b/precision);
     }
 
+    // assertEq with precision tolerance
+    function assertEq(uint a, uint b, bytes32 msg)  public {
+        emit log_named_bytes32(msg, "SystemTest - Assert Equal Failed");
+        assertEq(a, b);
+    }
+
+
     // assert equal two variables with a wei tolerance
     function assertEqTol(uint actual, uint expected, bytes32 msg) public {
         uint diff;

--- a/src/test/system/lender/mkr/mkr_scenarios.t.sol
+++ b/src/test/system/lender/mkr/mkr_scenarios.t.sol
@@ -139,9 +139,18 @@ contract LenderSystemTest is TestSuite, Interest {
         uint mkrAmount = 500 ether;
         _setUpMKRLine(juniorAmount, mkrAmount);
 
-        uint borrowAmount = 200 ether;
+        uint borrowAmount = 300 ether;
         setupOngoingLoan(borrowAmount);
         assertEq(currency.balanceOf(address(borrower)), borrowAmount, " testOnDemandDraw#1");
+        assertEq(clerk.debt(), 100 ether);
+    }
+
+    function testOnDemandDrawWithStabilityFee() public {
+        // todo not implemented
+    }
+
+    function testLoanRepayWipe() public {
+        // todo not implemented
     }
 
 }

--- a/src/test/system/setup.sol
+++ b/src/test/system/setup.sol
@@ -70,6 +70,7 @@ import {SimpleMkr} from "./../simple/mkr.sol";
 
 import "../../borrower/test/mock/shelf.sol";
 import "../../lender/test/mock/navFeed.sol";
+import "../../lender/adapters/mkr/test/mock/spotter.sol";
 
 // abstract contract
 contract LenderDeployerLike {
@@ -297,11 +298,14 @@ contract TestSetup  {
     }
 
     function _initMKR(LenderInit memory l) public {
-        mkr = new SimpleMkr(0, "drop", mkrMAT);
+        mkr = new SimpleMkr(0, "drop");
         address mkr_ = address(mkr);
 
+        SpotterMock spotter = new SpotterMock();
+        spotter.setReturn("mat", mkrMAT);
+
         mkrLenderDeployer.init(l.minSeniorRatio, l.maxSeniorRatio, l.maxReserve, l.challengeTime, l.seniorInterestRate, l.seniorTokenName,
-            l.seniorTokenSymbol, l.juniorTokenName, l.juniorTokenSymbol, address(mkr), address(mkr), address(mkr));
+            l.seniorTokenSymbol, l.juniorTokenName, l.juniorTokenSymbol, address(mkr), address(spotter), address(mkr));
     }
 
     function deployLender(bool mkrAdapter) public {

--- a/src/test/system/setup.sol
+++ b/src/test/system/setup.sol
@@ -298,7 +298,8 @@ contract TestSetup  {
     }
 
     function _initMKR(LenderInit memory l) public {
-        mkr = new SimpleMkr(0, "drop");
+        uint ONE = 10**27;
+        mkr = new SimpleMkr(ONE, "drop");
         address mkr_ = address(mkr);
 
         SpotterMock spotter = new SpotterMock();

--- a/src/test/system/test_suite.sol
+++ b/src/test/system/test_suite.sol
@@ -54,6 +54,12 @@ contract TestSuite is BaseSystemTest {
         assertEq(coordinator.lastEpochExecuted(), lastEpochExecuted);
     }
 
+    function setupOngoingLoan(uint borrowAmount) public {
+        // borrow loans maturity date 5 days from now
+        uint maturityDate = 5 days;
+        setupOngoingLoan(borrowAmount*3, borrowAmount, false, nftFeed.uniqueDayTimestamp(now) +maturityDate);
+    }
+
     function supplyAndBorrowFirstLoan(uint seniorSupplyAmount, uint juniorSupplyAmount,
         uint nftPrice, uint borrowAmount, uint maturityDate, ModelInput memory submission) public returns (uint loan, uint tokenId) {
         seniorSupply(seniorSupplyAmount);


### PR DESCRIPTION
**New Total Balance Function in Assessor**
- over time the `clerk.remainingCredit` will decrease because of the accumulated debt interest, therefore a buffer is reduced from the  remainingCredit to prevent the usage of currency which is not available.
- the buffer variable uses the stability fee multiplied with time constant( which should be way greater than minimumEpochClose time)

**Tests**
- added integration test for on demand draw in reserve