### PR TITLE
fix: reserve available update for a no orders epoch close

### DIFF
--- a/src/lender/coordinator.sol
+++ b/src/lender/coordinator.sol
@@ -205,6 +205,7 @@ contract EpochCoordinator is Auth, Math, FixedPoint  {
 
             // assessor performs re-balancing
             assessor.changeSeniorAsset(0, 0);
+            assessor.changeBorrowAmountEpoch(epochReserve);
             lastEpochExecuted = safeAdd(lastEpochExecuted, 1);
             return;
         }


### PR DESCRIPTION
**Desc**
- if an epoch was closed without any orders the currencyAvailable was not updated
- the currency of repaid loans should be available for new borrows