### PR TITLE
chore: new reserve improvement score implementation

### DIFF
--- a/src/lender/coordinator.sol
+++ b/src/lender/coordinator.sol
@@ -381,10 +381,8 @@ contract EpochCoordinator is Auth, Math, FixedPoint  {
             // highest possible score
             return BIG_NUMBER;
         }
-        // normalize reserve by defining maxReserve as ONE
-        Fixed27 memory normalizedNewReserve = Fixed27(rdiv(newReserve_, assessor.maxReserve()));
 
-        return rmul(IMPROVEMENT_WEIGHT, rdiv(ONE,  absDistance(safeDiv(ONE, 2), normalizedNewReserve.value)));
+        return rmul(IMPROVEMENT_WEIGHT, rdiv(ONE, safeSub(newReserve_, assessor.maxReserve())));
     }
 
     // the score improvement ratio uses the normalized distance to (minRatio+maxRatio)/2 as score

--- a/src/lender/test/coordinator-improvementScore.t.sol
+++ b/src/lender/test/coordinator-improvementScore.t.sol
@@ -243,5 +243,35 @@ contract CoordinatorImprovementScoreTest is CoordinatorTest, FixedPoint {
         assertEq(submitSolution(solution), coordinator.NEW_BEST());
         assertTrue(coordinator.gotFullValidSolution() == true);
     }
+
+    function testScoreRatioImprovementEdge() public {
+        LenderModel memory model = getDefaultModel();
+        model.maxReserve = 200 ether;
+
+        initTestConfig(model);
+
+        // newReserve <= maxReserve
+        uint newReserve = 199 ether;
+        assertEq(coordinator.scoreReserveImprovement(newReserve), coordinator.BIG_NUMBER());
+        // newReserve == maxReserve
+        newReserve = 200 ether;
+        assertEq(coordinator.scoreReserveImprovement(newReserve), coordinator.BIG_NUMBER());
+
+        assertTrue(coordinator.scoreReserveImprovement(201 ether) > coordinator.scoreReserveImprovement(202 ether));
+    }
+
+    function testScoreRatioImprovementZeroMaxReserve() public {
+        LenderModel memory model = getDefaultModel();
+        model.maxReserve = 0;
+
+        initTestConfig(model);
+        assertTrue(coordinator.scoreReserveImprovement(201 ether) > coordinator.scoreReserveImprovement(202 ether));
+        assertEq(coordinator.scoreReserveImprovement(0), coordinator.BIG_NUMBER());
+
+        uint lowestScore = coordinator.scoreReserveImprovement(uint(-1));
+        uint lowScore = coordinator.scoreReserveImprovement(10*18 * 1 ether);
+
+        assertTrue(lowScore > lowestScore);
+    }
 }
 


### PR DESCRIPTION
**Summary**
- removed normalised distance for coordinator reserveImprovementScore
   - the edge case of a zero maxReserve didn't allowed the normalization

- if the newReserve is bigger than the maxReserve the score is calculated in the following way
```
distance = newReserve-maxReserve; 
score = ONE/distance;
```
- the score will approximate zero for really high numbers
- tested up to `10^34` which should be enough for our use-case