### PR TITLE
feat: update default min epoch time to 23 hours 50 mins

### DIFF
--- a/src/lender/coordinator.sol
+++ b/src/lender/coordinator.sol
@@ -79,7 +79,8 @@ contract EpochCoordinator is Auth, Math, FixedPoint {
                         // timestamp last epoch closed
     uint                public lastEpochClosed;
                         // default minimum length of an epoch
-    uint                public minimumEpochTime = 1 days;
+                        // (1 day, with 10 min buffer, so we can close the epochs automatically on a daily basis at the same time)
+    uint                public minimumEpochTime = 1 days - 10 minutes;
 
     EpochTrancheLike    public juniorTranche;
     EpochTrancheLike    public seniorTranche;

--- a/src/lender/test/coordinator-base.t.sol
+++ b/src/lender/test/coordinator-base.t.sol
@@ -170,7 +170,7 @@ contract CoordinatorTest is DSTest, Math, BaseTypes {
     }
 
     function calcNextEpochIn() public view returns(uint) {
-        return (1 days) - (now - coordinator.lastEpochClosed());
+        return (1 days - 10 minutes) - (now - coordinator.lastEpochClosed());
     }
 
     function compareWithBest(ModelInput memory model_) internal {

--- a/src/lender/test/coordinator-base.t.sol
+++ b/src/lender/test/coordinator-base.t.sol
@@ -170,7 +170,7 @@ contract CoordinatorTest is DSTest, Math, BaseTypes {
     }
 
     function calcNextEpochIn() public view returns(uint) {
-        return (1 days - 10 minutes) - (now - coordinator.lastEpochClosed());
+        return (coordinator.minimumEpochTime()) - (now - coordinator.lastEpochClosed());
     }
 
     function compareWithBest(ModelInput memory model_) internal {
@@ -195,4 +195,3 @@ contract CoordinatorTest is DSTest, Math, BaseTypes {
         return rdiv(seniorAsset, model.NAV + currencyAvailable-currencyOut);
     }
 }
-

--- a/src/lender/test/coordinator-closeEpoch.t.sol
+++ b/src/lender/test/coordinator-closeEpoch.t.sol
@@ -28,7 +28,7 @@ contract CoordinatorCloseEpochTest is CoordinatorTest {
     function testMinimumEpochTime() public {
         assertEq(coordinator.lastEpochExecuted(), 0);
         assertEq(coordinator.currentEpoch(), 1);
-        hevm.warp(now + 1 days);
+        hevm.warp(now + 1 days - 10 minutes);
         // close and execute because no submissions
         coordinator.closeEpoch();
         assertEq(coordinator.currentEpoch(), 2);

--- a/src/lender/test/coordinator-closeEpoch.t.sol
+++ b/src/lender/test/coordinator-closeEpoch.t.sol
@@ -28,7 +28,7 @@ contract CoordinatorCloseEpochTest is CoordinatorTest {
     function testMinimumEpochTime() public {
         assertEq(coordinator.lastEpochExecuted(), 0);
         assertEq(coordinator.currentEpoch(), 1);
-        hevm.warp(now + 1 days - 10 minutes);
+        hevm.warp(now + coordinator.minimumEpochTime());
         // close and execute because no submissions
         coordinator.closeEpoch();
         assertEq(coordinator.currentEpoch(), 2);
@@ -113,4 +113,3 @@ contract CoordinatorCloseEpochTest is CoordinatorTest {
         assertEq(assessor.values_uint("borrow_amount"), 0);
     }
 }
-


### PR DESCRIPTION
We want to be able to automatically close epochs at 1 day intervals. This gives us 10 min buffer/leeway to do so.