### PR TITLE
fix: clerk.debt should drip mkr debt if needed

### DIFF
--- a/src/lender/adapters/mkr/clerk.sol
+++ b/src/lender/adapters/mkr/clerk.sol
@@ -387,7 +387,7 @@ contract Clerk is Auth, Math {
         mgr.file("owner", usr);
     }
 
-    // returns the debt and updates to vault debt in Maker if needed
+    // returns the debt and updates the vault debt in Maker if needed
     function debt() public returns(uint) {
         bytes32 ilk_ = ilk();
         (, uint rho) =  jug.ilks(ilk_);

--- a/src/lender/adapters/mkr/clerk.sol
+++ b/src/lender/adapters/mkr/clerk.sol
@@ -177,7 +177,7 @@ contract Clerk is Auth, Math {
 
     function remainingCredit() public view returns (uint) {
         uint debt_ = cdptab();
-        if (creditline <= (debt_) || mkrActive() == false) {
+        if (creditline <= debt_ || mkrActive() == false) {
             return 0;
         }
         return safeSub(creditline, debt_);

--- a/src/lender/adapters/mkr/clerk.sol
+++ b/src/lender/adapters/mkr/clerk.sol
@@ -276,7 +276,7 @@ contract Clerk is Auth, Math {
     }
 
     function _harvest(uint dropPrice) internal {
-        require((cdpink() > 0), "nothing-profit-to-harvest");
+        require((cdpink() > 0), "no-profit-to-harvest");
 
         uint lockedCollateralDAI = rmul(cdpink(), dropPrice);
         // profit => diff between the DAI value of the locked collateral in the cdp & the actual cdp debt including protection buffer

--- a/src/lender/adapters/mkr/test/mock/jug.sol
+++ b/src/lender/adapters/mkr/test/mock/jug.sol
@@ -1,0 +1,32 @@
+// Copyright (C) 2020 Centrifuge
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+pragma solidity >=0.5.15 <0.6.0;
+
+import "../../../../../test/mock/mock.sol";
+
+contract JugMock is Mock {
+    function ilks(bytes32 ilk) public view returns (uint ,uint) {
+        return (values_return["ilks_duty"], values_return["ilks_rho"]);
+    }
+
+    function drip(bytes32 ilk) public returns(uint) {
+        calls["drip"]++;
+        values_bytes32["drip_ilk"] = ilk;
+        return values_return["ilks_rates"];
+    }
+
+    function base() public returns(uint) {
+        return values_return["base"];
+    }
+}

--- a/src/lender/reserve.sol
+++ b/src/lender/reserve.sol
@@ -25,7 +25,7 @@ interface LendingAdapter {
     function remainingCredit() external view returns (uint);
     function draw(uint amount) external;
     function wipe(uint amount) external;
-    function debt() external view returns(uint);
+    function debt() external returns(uint);
     function activated() external view returns(bool);
 }
 

--- a/src/test/simple/mkr.sol
+++ b/src/test/simple/mkr.sol
@@ -15,17 +15,18 @@ interface ERC20Like {
 // contract will mint currency tokens to simulate the mkr behaviour
 // implements mgr, spotter, vat interfaces
 contract JugMock {
-      uint public duty;
-      function file(bytes32 what, uint value) external {
+    uint public duty;
+    function file(bytes32 what, uint value) external {
+        if(what == "duty") {
+          duty = value;
+        }
+    }
 
-          if(what == "duty") {
-              duty = value;
-          }
-      }
+    function ilks(bytes32 ilk) public view returns (uint ,uint) {
+      return (duty, 0);
+    }
 
-      function ilks(bytes32 ilk) public view returns (uint ,uint) {
-          return (duty, 0);
-      }
+    function drip(bytes32 ilk) public returns(uint) {return 0;}
 }
 
 contract UrnMock {

--- a/src/test/system/lender/mkr/mkr_scenarios.t.sol
+++ b/src/test/system/lender/mkr/mkr_scenarios.t.sol
@@ -373,5 +373,4 @@ contract MKRLenderSystemTest is MKRTestBasis {
         // juniorTokenPrice should be still ONE
         assertEq(currency.balanceOf(address(juniorInvestor)), payoutCurrency);
     }
-
 }


### PR DESCRIPTION
**Content**
- `clerk.debt()` function should update the maker debt if not up to date
- all non view methods should use `debt()` instead of `cdptab()`

We should discuss if we want to add a `calcDebt()` function which calculates the debt for all `view` methods

**Pseudo Code for calcDebt()**
```javascript
function calcDebt() public view returns(uint) {
    bytes32 ilk_ = ilk();
    (, uint art) = vat.urns(ilk_, mgr.urn());
    (, uint prev) = vat.ilks(ilk_);
    (uint duty, uint rho) = jug.ilks(ilk_);
    return rmul(art, rmul(rpow(safeAdd(jug.base(), duty), block.timestamp - rho, ONE), prev));
}
```