### PR TITLE
feat: clerk added wipeThreshold and fix sink borrowAmountEpoch

### DIFF
--- a/src/lender/adapters/mkr/clerk.sol
+++ b/src/lender/adapters/mkr/clerk.sol
@@ -122,6 +122,8 @@ contract Clerk is Auth, Interest {
     ERC20Like public dai;
     ERC20Like public collateral;
 
+    uint public constant WAD = 10*18;
+
     // buffer to add on top of mat to avoid cdp liquidation => default 1%
     uint public matBuffer = 0.01 * 10**27;
 
@@ -130,7 +132,7 @@ contract Clerk is Auth, Interest {
 
     // the debt is only repaid if amount is higher than the threshold
     // repaying a lower amount would cause more cost in gas fees than the debt reduction
-    uint public wipeThreshold = 10**18;
+    uint public wipeThreshold = 1 * WAD;
 
     // adapter functions can only be active if the tinlake pool is currently not in epoch closing/submissions/execution state
     modifier active() { require(activated(), "epoch-closing"); _; }

--- a/src/lender/adapters/mkr/clerk.sol
+++ b/src/lender/adapters/mkr/clerk.sol
@@ -256,15 +256,15 @@ contract Clerk is Auth, Interest {
 
     // transfer DAI from reserve, wipe cdp debt, exit DROP from cdp, burn DROP, harvest junior profit
     function wipe(uint amountDAI) public auth active {
-        uint debt_ = debt();
-        require((debt_ > 0), "cdp-debt-already-repaid");
-
         // if amountDAI is too low, required transaction fees of wipe would be higher
         // only continue with wipe if amountDAI is higher than wipeThreshold;
         if(amountDAI < wipeThreshold) {
-           return;
+            return;
         }
 
+        uint debt_ = debt();
+        require((debt_ > 0), "cdp-debt-already-repaid");
+        
         // repayment amount should not exceed cdp debt
         if (amountDAI > debt_) {
             amountDAI = debt_;

--- a/src/lender/adapters/mkr/clerk.sol
+++ b/src/lender/adapters/mkr/clerk.sol
@@ -177,7 +177,7 @@ contract Clerk is Auth, Interest {
         } else if (what == "tolerance") {
             collateralTolerance = value;
         } else if (what == "wipeThreshold") {
-            collateralTolerance = value;
+            wipeThreshold = value;
         } else { revert(); }
     }
 

--- a/src/lender/adapters/mkr/test/clerk.t.sol
+++ b/src/lender/adapters/mkr/test/clerk.t.sol
@@ -401,6 +401,10 @@ contract ClerkTest is Assertions, Interest {
         // wipe should happen because it is exactly the threshold
         wipeAmountTooLow(clerk.wipeThreshold());
     }
+    function testWipeThresholdFile() public {
+        clerk.file("wipeThreshold", 123);
+        assertEq(clerk.wipeThreshold(), 123);
+    }
 
     function testPartialWipe() public {
         testFullDraw();

--- a/src/lender/adapters/mkr/test/clerk.t.sol
+++ b/src/lender/adapters/mkr/test/clerk.t.sol
@@ -436,7 +436,7 @@ contract ClerkTest is Assertions, Interest {
         // make sure reserve has enough DAI
         currency.mint(address(reserve), tab);
         // repay full debt
-        wipe(rmul(tab, 2), dropPrice);
+        wipe(tab, dropPrice);
     }
 
     function testFailWipeNoDebt() public {
@@ -533,6 +533,20 @@ contract ClerkTest is Assertions, Interest {
         testFullWipe();
         uint creditline = clerk.creditline();
         sink(creditline);
+    }
+
+    function testSinkLowerBorrowAmountEpoch() public {
+        testFullWipe();
+        uint creditline = clerk.creditline();
+        assessor.setReturn("borrowAmountEpoch", creditline/2);
+
+        uint reserve = 1000 ether;
+        uint seniorBalance = 800 ether;
+        assessor.setReturn("balance", reserve);
+        assessor.setReturn("seniorBalance", seniorBalance);
+        // raise creditLine
+        clerk.sink(creditline);
+        assertEq(assessor.values_uint("changeBorrowAmountEpoch"),0);
     }
 
     function testPartialSink() public {

--- a/src/lender/adapters/mkr/test/clerk.t.sol
+++ b/src/lender/adapters/mkr/test/clerk.t.sol
@@ -386,6 +386,22 @@ contract ClerkTest is Assertions, Interest {
         wipe(tab, dropPrice);
     }
 
+    function wipeAmountTooLow(uint amountDAI) public {
+        testFullDraw();
+        uint preReserve = currency.balanceOf(address(reserve));
+        clerk.wipe(amountDAI);
+        assertEq(currency.balanceOf(address(reserve)), preReserve);
+    }
+
+    function testWipeAmountTooLow() public {
+        wipeAmountTooLow(clerk.wipeThreshold() -1);
+    }
+
+    function testFailWipeAmountTooLow() public {
+        // wipe should happen because it is exactly the threshold
+        wipeAmountTooLow(clerk.wipeThreshold());
+    }
+
     function testPartialWipe() public {
         testFullDraw();
         // increase dropPrice

--- a/src/lender/test/coordinator-executeEpoch.t.sol
+++ b/src/lender/test/coordinator-executeEpoch.t.sol
@@ -94,11 +94,10 @@ contract CoordinatorExecuteEpochTest is CoordinatorTest {
         assertEq(seniorAsset, shouldSeniorAsset);
 
         uint shouldRatio = rdiv(seniorAsset, safeAdd(shouldNewReserve, model_.NAV));
-
         uint currSeniorRatio = assessor.calcSeniorRatio(shouldSeniorAsset, model_.NAV, shouldNewReserve);
 
         assertEq(currSeniorRatio, shouldRatio);
-        assertEq(assessor.values_uint("borrow_amount"), shouldNewReserve);
+        assertEq(assessor.values_uint("changeBorrowAmountEpoch"), shouldNewReserve);
 
       //  assertEq(assessor.values_uint("updateSenior_seniorDebt"), rmul(model_.NAV, currSeniorRatio));
     }

--- a/src/lender/test/mock/assessor.sol
+++ b/src/lender/test/mock/assessor.sol
@@ -152,7 +152,7 @@ contract AssessorMock is Mock {
     }
 
     function changeBorrowAmountEpoch(uint currencyAmount) public {
-        values_uint["borrow_amount"] = currencyAmount;
+        values_uint["changeBorrowAmountEpoch"] = currencyAmount;
     }
 
     function borrowAmountEpoch() public view returns(uint) {


### PR DESCRIPTION
 ### Content
   **clerk added wipeThreshold**
   - the debt is only repaid if amount is higher than the  wipe threshold
   -  repaying a lower amount would cause more cost in gas fees than the debt reduction
   
   **clerk  sink epochBorrowAmount**
   - the sink amount can be higher than assessor. borrowAmountEpoch
   - in that case  assessor. borrowAmountEpoch can be set to zero otherwise the safeSub would fail