### PR TITLE
fix: B08, B12, several improvements

### DIFF
--- a/src/borrower/feed/navfeed.sol
+++ b/src/borrower/feed/navfeed.sol
@@ -105,6 +105,7 @@ abstract contract NAVFeed is Auth, Discounting {
         uint rate_, uint recoveryRatePD_);
     event File(bytes32 indexed name, bytes32 nftID_, uint maturityDate_);
     event File(bytes32 indexed name, uint value);
+    event File(bytes32 indexed name, uint rate_, uint writeOffPercentage_, uint overdueDays_);
     event WriteOff(uint indexed loan, uint indexed writeOffGroupsIndex, bool override_);
 
     // getter functions
@@ -190,6 +191,7 @@ abstract contract NAVFeed is Auth, Discounting {
             uint index = writeOffGroups.length;
             writeOffGroups.push(WriteOffGroup(toUint128(writeOffPercentage_), toUint128(overdueDays_)));
             pile.file("rate", safeAdd(WRITEOFF_RATE_GROUP_START, index), rate_);
+            emit File(name, rate_, writeOffPercentage_, overdueDays_);
         } else { revert ("unknown name");}
     }
 
@@ -221,7 +223,7 @@ abstract contract NAVFeed is Auth, Discounting {
         loanDetails[loan].borrowed = toUint128(safeAdd(borrowed(loan), amount));
 
         // return increase NAV amount
-        uint navIncrease = calcDiscount(discountRate.value, fv, nnow, maturityDate_);
+        navIncrease = calcDiscount(discountRate.value, fv, nnow, maturityDate_);
 
         latestDiscount = safeAdd(latestDiscount, navIncrease);
         latestNAV = safeAdd(latestNAV, navIncrease);

--- a/src/borrower/pile.sol
+++ b/src/borrower/pile.sol
@@ -81,11 +81,11 @@ contract Pile is Auth, Interest {
 
         if (currencyAmount > total) {
             total = 0;
+            emit DecreaseDebt(loan, currencyAmount);
             return;
         }
 
         total = safeSub(total, currencyAmount);
-
         emit DecreaseDebt(loan, currencyAmount);
     }
 

--- a/src/borrower/shelf.sol
+++ b/src/borrower/shelf.sol
@@ -130,7 +130,7 @@ contract Shelf is Auth, TitleOwned, Math {
     }
 
     function close(uint loan) external {
-        require(!nftLocked(loan), "nft-not-locked");
+        require(!nftLocked(loan), "nft-locked");
         (address registry, uint tokenId) = token(loan);
         require(title.ownerOf(loan) == msg.sender || NFTLike(registry).ownerOf(tokenId) == msg.sender, "not-loan-or-nft-owner");
         title.close(loan);

--- a/src/borrower/shelf.sol
+++ b/src/borrower/shelf.sol
@@ -61,7 +61,6 @@ contract Shelf is Auth, TitleOwned, Math {
     SubscriberLike      public subscriber;
 
     uint                public balance;
-    address             public lender;
 
     struct Loan {
         address registry;
@@ -96,12 +95,7 @@ contract Shelf is Auth, TitleOwned, Math {
 
     // sets the dependency to another contract
     function depend(bytes32 contractName, address addr) external auth {
-        if (contractName == "lender") {
-            if (lender != address(0)) currency.approve(lender, uint(0));
-            currency.approve(addr, type(uint256).max);
-            lender = addr;
-        }
-        else if (contractName == "token") { currency = TokenLike(addr); }
+        if (contractName == "token") { currency = TokenLike(addr); }
         else if (contractName == "title") { title = TitleLike(addr); }
         else if (contractName == "pile") { pile = PileLike(addr); }
         else if (contractName == "ceiling") { ceiling = NAVFeedLike(addr); }

--- a/src/lender/assessor.sol
+++ b/src/lender/assessor.sol
@@ -113,9 +113,9 @@ contract Assessor is Definitions, Auth, Interest {
 
     function reBalance(uint seniorAsset_) internal {
         // re-balancing according to new ratio
-        // we use the approximated NAV here because during the submission period
+        // we use the actual NAV here because during the submission period
         // new loans might have been repaid in the meanwhile which are not considered in the epochNAV
-        uint nav_ = navFeed.latestNAV();
+        uint nav_ = getNAV();
         uint reserve_ = reserve.totalBalance();
 
         uint seniorRatio_ = calcSeniorRatio(seniorAsset_, nav_, reserve_);
@@ -149,7 +149,7 @@ contract Assessor is Definitions, Auth, Interest {
     }
 
     function calcSeniorTokenPrice() external view returns(uint) {
-        return calcSeniorTokenPrice(navFeed.latestNAV(), reserve.totalBalance());
+        return calcSeniorTokenPrice(getNAV(), reserve.totalBalance());
     }
 
     function calcSeniorTokenPrice(uint nav_, uint) public view returns(uint) {
@@ -157,7 +157,7 @@ contract Assessor is Definitions, Auth, Interest {
     }
 
     function calcJuniorTokenPrice() external view returns(uint) {
-        return _calcJuniorTokenPrice(navFeed.latestNAV(), reserve.totalBalance());
+        return _calcJuniorTokenPrice(getNAV(), reserve.totalBalance());
     }
 
     function calcJuniorTokenPrice(uint nav_, uint) public view returns (uint) {
@@ -165,7 +165,7 @@ contract Assessor is Definitions, Auth, Interest {
     }
 
     function calcTokenPrices() external view returns (uint, uint) {
-        uint epochNAV = navFeed.latestNAV();
+        uint epochNAV = getNAV();
         uint epochReserve = reserve.totalBalance();
         return calcTokenPrices(epochNAV, epochReserve);
     }
@@ -250,13 +250,8 @@ contract Assessor is Definitions, Auth, Interest {
     }
 
     // returns the current NAV
-    function currentNAV() public view returns(uint) {
-        return navFeed.currentNAV();
-    }
-
-    // returns the approximated NAV for gas-performance reasons
     function getNAV() public view returns(uint) {
-        return navFeed.latestNAV();
+        return navFeed.currentNAV();
     }
 
     // changes the total amount available for borrowing loans
@@ -272,7 +267,7 @@ contract Assessor is Definitions, Auth, Interest {
     // juniorRatio is denominated in RAY (10^27)
     function calcJuniorRatio() public view returns(uint) {
         uint seniorAsset = safeAdd(seniorDebt(), seniorBalance_);
-        uint assets = safeAdd(navFeed.latestNAV(), reserve.totalBalance());
+        uint assets = safeAdd(getNAV(), reserve.totalBalance());
 
         if(seniorAsset == 0 && assets == 0) {
             return 0;

--- a/src/lender/test/assessor.t.sol
+++ b/src/lender/test/assessor.t.sol
@@ -110,7 +110,7 @@ contract AssessorTest is DSTest, Math {
         uint seniorSupply =  80 ether;
         uint seniorRedeem = 0;
 
-        navFeed.setReturn("latestNAV", 10 ether);
+        navFeed.setReturn("currentNAV", 10 ether);
         reserveMock.setReturn("balance", 90 ether);
 
 
@@ -123,7 +123,7 @@ contract AssessorTest is DSTest, Math {
         uint seniorSupply =  300 ether;
         uint seniorRedeem = 0;
 
-        navFeed.setReturn("latestNAV", 200 ether);
+        navFeed.setReturn("currentNAV", 200 ether);
         reserveMock.setReturn("balance", 0 ether);
 
         assessor.changeSeniorAsset(seniorSupply, seniorRedeem);
@@ -137,7 +137,7 @@ contract AssessorTest is DSTest, Math {
         uint seniorSupply =  100 ether;
         uint seniorRedeem = 0;
 
-        navFeed.setReturn("latestNAV", 10 ether);
+        navFeed.setReturn("currentNAV", 10 ether);
         reserveMock.setReturn("balance", 90 ether);
 
 
@@ -150,7 +150,7 @@ contract AssessorTest is DSTest, Math {
         uint seniorSupply =  100 ether;
         uint seniorRedeem = 0;
 
-        navFeed.setReturn("latestNAV", 0);
+        navFeed.setReturn("currentNAV", 0);
         reserveMock.setReturn("balance", 120 ether);
 
 
@@ -163,7 +163,7 @@ contract AssessorTest is DSTest, Math {
         uint seniorSupply =  100 ether;
         uint seniorRedeem = 0;
 
-        navFeed.setReturn("latestNAV", 10 ether);
+        navFeed.setReturn("currentNAV", 10 ether);
         reserveMock.setReturn("balance", 50 ether);
 
 
@@ -177,7 +177,7 @@ contract AssessorTest is DSTest, Math {
         uint interestRate = uint(1000000564701133626865910626);
         assessor.file("seniorInterestRate", interestRate);
 
-        navFeed.setReturn("latestNAV", 200 ether);
+        navFeed.setReturn("currentNAV", 200 ether);
         reserveMock.setReturn("balance", 200 ether);
 
         uint seniorSupply = 200 ether;
@@ -211,7 +211,7 @@ contract AssessorTest is DSTest, Math {
 
     function testCalcSeniorTokenPriceWithSupplyRoundingError() public {
         uint nav = 10 ether;
-        navFeed.setReturn("latestNAV", nav);
+        navFeed.setReturn("currentNAV", nav);
         uint seniorTokenSupply = 2; // set value in range of supply rounding tolearnce
         reserveMock.setReturn("balance", 100 ether);
         seniorTranche.setReturn("tokenSupply", seniorTokenSupply);
@@ -223,7 +223,7 @@ contract AssessorTest is DSTest, Math {
     
     function testCalcSeniorTokenPrice() public {
         uint nav = 10 ether;
-        navFeed.setReturn("latestNAV", nav);
+        navFeed.setReturn("currentNAV", nav);
         uint seniorSupply = 80 ether;
         reserveMock.setReturn("balance", 100 ether);
 
@@ -242,7 +242,7 @@ contract AssessorTest is DSTest, Math {
 
     function testCalcJuniorTokenPrice() public {
         uint nav = 10 ether;
-        navFeed.setReturn("latestNAV", nav);
+        navFeed.setReturn("currentNAV", nav);
         uint seniorSupply = 80 ether;
         reserveMock.setReturn("balance", 90 ether);
 
@@ -267,7 +267,7 @@ contract AssessorTest is DSTest, Math {
         uint nav = 200 ether;
 
 
-        navFeed.setReturn("latestNAV", 200 ether);
+        navFeed.setReturn("currentNAV", 200 ether);
         reserveMock.setReturn("balance", 200 ether);
 
         uint seniorSupply = 200 ether;

--- a/src/lender/test/mock/assessor.sol
+++ b/src/lender/test/mock/assessor.sol
@@ -136,10 +136,6 @@ contract AssessorMock is Mock {
         return values_return["borrowAmountEpoch"];
     }
 
-    function currentNAV() public view returns(uint) {
-        return values_uint["currentNAV"];
-    }
-
     function getNAV() public view returns(uint) {
         return values_uint["getNAV"];
     }

--- a/src/root.sol
+++ b/src/root.sol
@@ -86,9 +86,7 @@ contract TinlakeRoot is Auth {
         address assessor_ = lenderDeployer.assessor();
 
         // Borrower depends
-        DependLike(borrowerDeployer.shelf()).depend("lender", reserve_);
         DependLike(borrowerDeployer.shelf()).depend("reserve", reserve_);
-
         DependLike(borrowerDeployer.shelf()).depend("assessor", assessor_);
 
         // Lender depends

--- a/src/test/system/lender/mkr/mkr_basic.t.sol
+++ b/src/test/system/lender/mkr/mkr_basic.t.sol
@@ -96,7 +96,7 @@ contract MKRTestBasis is TestSuite, Interest {
 
     function _mkrLiquidationPostAssertions() public {
         //sanity check - correct currency amount for each token
-        assertEqTol(mkrAssessor.currentNAV() + reserve.totalBalance(), rmul(seniorToken.totalSupply(), mkrAssessor.calcSeniorTokenPrice())
+        assertEqTol(mkrAssessor.getNAV() + reserve.totalBalance(), rmul(seniorToken.totalSupply(), mkrAssessor.calcSeniorTokenPrice())
             + rmul(juniorToken.totalSupply(), mkrAssessor.calcJuniorTokenPrice()),  "mkrPostCon#1");
 
         assertEqTol(clerk.remainingCredit(), 0,  "mkrPostCon#2");

--- a/src/test/system/lender/mkr/mkr_scenarios.t.sol
+++ b/src/test/system/lender/mkr/mkr_scenarios.t.sol
@@ -171,7 +171,7 @@ contract MKRLenderSystemTest is MKRTestBasis {
 
         // repay loans and everybody redeems
         repayAllDebtDefaultLoan();
-        assertEq(mkrAssessor.currentNAV(), 0);
+        assertEq(mkrAssessor.getNAV(), 0);
         // reserve should keep the currency no automatic clerk.wipe
         assertTrue(reserve.totalBalance() > 0);
 


### PR DESCRIPTION
Bugfixes:
- B08. DecreaseDebt Event is not emitted if the last loan debt is decreased with an rounding error
- B12. Outdated NAV value used in assessor.sol

Improvements:
- I12. Unused storage variable in Title
- I13. Unnecessary separation of roles in Shelf
- I15. Unnecessary separation of logic in Shelf
- I16. Missing File event in navFeed.sol writeOffGroup
- I17. Unnecessary conversion to uniqueDayTimestamp for maturityDate(nftID_) in navFeed.sol
- I18. Incorrect require error message statements in shelf.close require(!nftLocked(loan), "nft-not-locked");
- I19. Use nnow instead of uniqueDayTimestamp(block.timestamp) in navfeed.repay calcDiscount