### PR TITLE
test: fix timestamp independent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,4 +4,4 @@ dapp_update :; dapp update
 build       :; dapp build
 clean       :; dapp clean
 test        :; dapp test
-test_deep   :; dapp test --fuzz-runs 50000
+test_deep   :; dapp test --fuzz-runs 30000

--- a/src/lender/test/memberlist.t.sol
+++ b/src/lender/test/memberlist.t.sol
@@ -5,13 +5,16 @@ import "ds-test/test.sol";
 import "../token/memberlist.sol";
 import "tinlake-math/math.sol";
 
+interface Hevm {
+    function warp(uint256) external;
+}
 
 contract MemberlistTest is Math, DSTest {
-
-    uint memberlistValidity = safeAdd(block.timestamp, 8 days);
+    uint memberlistValidity;
     Memberlist memberlist;
     Memberlist testMemberlist;
     Memberlist testMemberlist1;
+    Hevm hevm;
 
     address self;
     address memberlist_;
@@ -21,10 +24,14 @@ contract MemberlistTest is Math, DSTest {
         memberlist = new Memberlist();
         self = address(this);
         memberlist_ = address(memberlist);
+        memberlist_ = address(memberlist);
         members = new address[](3);
         members[0] = address(1);
         members[1] = address(2);
         members[2] = address(3);
+        hevm = Hevm(HEVM_ADDRESS);
+        hevm.warp(block.timestamp + 1 days);
+        memberlistValidity = safeAdd(block.timestamp, 8 days);
     }
 
     function testAddMember() public {
@@ -59,9 +66,9 @@ contract MemberlistTest is Math, DSTest {
 
     function testFailIsMemberNotAdded() public view {
         memberlist.member(self);
-    }   
+    }
 
     function testFailHasMemberNotAdded() public view {
          assert(memberlist.hasMember(self));
-    }   
+    }
 }

--- a/src/lender/test/operator.t.sol
+++ b/src/lender/test/operator.t.sol
@@ -9,6 +9,9 @@ import "../token/restricted.sol";
 import "../token/memberlist.sol";
 import "tinlake-math/math.sol";
 
+interface Hevm {
+    function warp(uint256) external;
+}
 
 contract OperatorTest is Math, DSTest {
 
@@ -17,6 +20,7 @@ contract OperatorTest is Math, DSTest {
     Operator operator;
     Memberlist memberlist;
     RestrictedToken token;
+    Hevm hevm;
 
     address self;
     address operator_;
@@ -32,6 +36,8 @@ contract OperatorTest is Math, DSTest {
 
         self = address(this);
         operator_ = address(operator);
+        hevm = Hevm(HEVM_ADDRESS);
+        hevm.warp(block.timestamp + 1 days);
     }
 
     function testSupplyOrder() public {

--- a/src/lender/test/restricted-token.t.sol
+++ b/src/lender/test/restricted-token.t.sol
@@ -16,8 +16,8 @@ interface Hevm {
 contract RestrictedTokenTest is Math, DSTest {
 
     Hevm hevm;
-    
-    uint memberlistValidity = safeAdd(block.timestamp, 8 days);
+
+    uint memberlistValidity;
     Memberlist memberlist;
     RestrictedToken token;
 
@@ -30,7 +30,7 @@ contract RestrictedTokenTest is Math, DSTest {
         memberlist = new Memberlist();
         token = new RestrictedToken("TST", "TST");
         token.depend("memberlist", address(memberlist));
-        
+
         TestUser randomUser = new TestUser();
         randomUser_ = address(randomUser);
 
@@ -41,7 +41,8 @@ contract RestrictedTokenTest is Math, DSTest {
         token.mint(self, 100 ether);
 
         hevm = Hevm(HEVM_ADDRESS);
-        hevm.warp(block.timestamp);
+        hevm.warp(block.timestamp + 1 days);
+        memberlistValidity = safeAdd(block.timestamp, 8 days);
     }
 
     function testReceiveTokens() public {


### PR DESCRIPTION
- some tests were not working with a `DAPP_TEST_TIMESTAMP=0`
- changed fuzz testing to a lower amount