### PR TITLE
docs: added NatSpec comments for borrower contracts

### DIFF
--- a/src/borrower/deployer.sol
+++ b/src/borrower/deployer.sol
@@ -100,8 +100,9 @@ contract BorrowerDeployer is FixedPoint {
         feed = feedFab.newFeed();
         AuthLike(feed).rely(root);
     }
-    /// @notice deploys the borrower contracts and wires them together
 
+    /// @notice deploys the borrower contracts and wires them together
+    /// @param initNAVFeed boolean flag if a NAV feed should be deployed
     function deploy(bool initNAVFeed) public {
         // ensures all required deploy methods were called
         require(shelf != ZERO);

--- a/src/borrower/deployer.sol
+++ b/src/borrower/deployer.sol
@@ -93,8 +93,8 @@ contract BorrowerDeployer is FixedPoint {
         shelf = shelffab.newShelf(currency, address(title), address(pile), address(feed));
         AuthLike(shelf).rely(root);
     }
-    /// @notice deploys the feed contract
 
+    /// @notice deploys the feed contract
     function deployFeed() public {
         require(feed == ZERO);
         feed = feedFab.newFeed();

--- a/src/borrower/deployer.sol
+++ b/src/borrower/deployer.sol
@@ -25,6 +25,7 @@ interface FileLike {
     function file(bytes32 name, uint256 value) external;
 }
 
+/// @notice Borrower Deployer contract
 contract BorrowerDeployer is FixedPoint {
     address public immutable root;
 
@@ -72,29 +73,34 @@ contract BorrowerDeployer is FixedPoint {
         discountRate = Fixed27(discountRate_);
     }
 
+    /// @notice deploys the pile contract
     function deployPile() public {
         require(pile == ZERO);
         pile = pilefab.newPile();
         AuthLike(pile).rely(root);
     }
+    /// @notice deploys the title contract
 
     function deployTitle() public {
         require(title == ZERO);
         title = titlefab.newTitle(titleName, titleSymbol);
         AuthLike(title).rely(root);
     }
+    /// @notice deploys the shelf contract
 
     function deployShelf() public {
         require(shelf == ZERO && title != ZERO && pile != ZERO && feed != ZERO);
         shelf = shelffab.newShelf(currency, address(title), address(pile), address(feed));
         AuthLike(shelf).rely(root);
     }
+    /// @notice deploys the feed contract
 
     function deployFeed() public {
         require(feed == ZERO);
         feed = feedFab.newFeed();
         AuthLike(feed).rely(root);
     }
+    /// @notice deploys the borrower contracts and wires them together
 
     function deploy(bool initNAVFeed) public {
         // ensures all required deploy methods were called
@@ -122,8 +128,10 @@ contract BorrowerDeployer is FixedPoint {
             NAVFeedLike(feed).init();
         }
     }
+    /// @notice deploys the borrower contracts and wires them together without a NAVFeed
 
     function deploy() public {
+        // doesn't deploy the NAV feed
         deploy(false);
     }
 }

--- a/src/borrower/fabs/navfeed.creditline.sol
+++ b/src/borrower/fabs/navfeed.creditline.sol
@@ -3,6 +3,7 @@ pragma solidity >=0.7.6;
 
 import {CreditlineNAVFeed} from "./../feed/creditline.sol";
 
+/// @notice factory contract for creditline nav feed
 contract CreditlineNAVFeedFab {
     function newFeed() public returns (address) {
         CreditlineNAVFeed feed = new CreditlineNAVFeed();

--- a/src/borrower/fabs/navfeed.principal.sol
+++ b/src/borrower/fabs/navfeed.principal.sol
@@ -3,6 +3,7 @@ pragma solidity >=0.7.6;
 
 import {NAVFeed} from "./../feed/navfeed.sol";
 
+/// @notice factory contract for principal nav feed
 contract PrincipalNAVFeedFab {
     function newFeed() public returns (address) {
         NAVFeed feed = new NAVFeed();

--- a/src/borrower/fabs/pile.sol
+++ b/src/borrower/fabs/pile.sol
@@ -3,6 +3,7 @@ pragma solidity >=0.7.6;
 
 import {Pile} from "./../pile.sol";
 
+/// @notice factory contract for the pile contract
 contract PileFab {
     function newPile() public returns (address) {
         Pile pile = new Pile();

--- a/src/borrower/fabs/shelf.sol
+++ b/src/borrower/fabs/shelf.sol
@@ -3,6 +3,7 @@ pragma solidity >=0.7.6;
 
 import {Shelf} from "./../shelf.sol";
 
+/// @notice factory contract for the shelf contract
 contract ShelfFab {
     function newShelf(address tkn_, address title_, address debt_, address ceiling_) public returns (address) {
         Shelf shelf = new Shelf(tkn_, title_, debt_, ceiling_);

--- a/src/borrower/fabs/title.sol
+++ b/src/borrower/fabs/title.sol
@@ -3,6 +3,7 @@ pragma solidity >=0.7.6;
 
 import {Title} from "tinlake-title/title.sol";
 
+/// @notice factory contract for the title contract
 contract TitleFab {
     function newTitle(string memory name, string memory symbol) public returns (address) {
         Title title = new Title(name, symbol);

--- a/src/borrower/feed/creditline.sol
+++ b/src/borrower/feed/creditline.sol
@@ -3,7 +3,10 @@ pragma solidity >=0.7.6;
 
 import "./navfeed.sol";
 
+/// @notice CreditlineNAVFeed contract ceiling is based on collateral value
 contract CreditlineNAVFeed is NAVFeed {
+    /// @notice returns the ceiling (max borrow amount) for a loan
+    /// @param loan the loan id
     function ceiling(uint256 loan) public view override returns (uint256) {
         bytes32 nftID_ = nftID(loan);
         uint256 initialCeiling = rmul(nftValues(nftID_), ceilingRatio(risk(nftID_)));

--- a/src/borrower/feed/discounting.sol
+++ b/src/borrower/feed/discounting.sol
@@ -3,7 +3,7 @@ pragma solidity >=0.7.6;
 
 import "tinlake-math/math.sol";
 
-/// @notice Discounting contract without a state which defines the relevant formulars for the navfeed
+/// @notice Discounting contract without a state which defines the relevant formulas for the navfeed
 contract Discounting is Math {
     /// @notice calculates the discount for a given loan
     /// @param discountRate the discount rate
@@ -52,8 +52,8 @@ contract Discounting is Math {
 
     /// @notice normalizes a timestamp to round down to the nearest midnight (UTC)
     /// @param timestamp the timestamp which should be normalized
-    /// @return nTimstamp normalized timestamp
-    function uniqueDayTimestamp(uint256 timestamp) public pure returns (uint256 nTimstamp) {
+    /// @return nTimestamp normalized timestamp
+    function uniqueDayTimestamp(uint256 timestamp) public pure returns (uint256 nTimestamp) {
         return (1 days) * (timestamp / (1 days));
     }
     /// @notice rpow peforms a math pow operation with fixed point number

--- a/src/borrower/feed/discounting.sol
+++ b/src/borrower/feed/discounting.sol
@@ -3,42 +3,65 @@ pragma solidity >=0.7.6;
 
 import "tinlake-math/math.sol";
 
-// contract without a state which defines the relevant formulars for the navfeed
+/// @notice Discounting contract without a state which defines the relevant formulars for the navfeed
 contract Discounting is Math {
-    function calcDiscount(uint256 discountRate, uint256 fv, uint256 normalizedBlockTimestamp, uint256 maturityDate_)
+    /// @notice calculates the discount for a given loan
+    /// @param discountRate the discount rate
+    /// @param fv the future value of the loan
+    /// @param normalizedBlockTimestamp the normalized block time (each day to midnight)
+    /// @param maturityDate the maturity date of the loan
+    /// @return result discount for the loan
+    function calcDiscount(uint256 discountRate, uint256 fv, uint256 normalizedBlockTimestamp, uint256 maturityDate)
         public
         pure
         returns (uint256 result)
     {
-        return rdiv(fv, rpow(discountRate, safeSub(maturityDate_, normalizedBlockTimestamp), ONE));
+        return rdiv(fv, rpow(discountRate, safeSub(maturityDate, normalizedBlockTimestamp), ONE));
     }
 
-    // calculate the future value based on the amount, maturityDate interestRate and recoveryRate
-    function calcFutureValue(uint256 loanInterestRate, uint256 amount, uint256 maturityDate_, uint256 recoveryRatePD_)
+    /// @notice calculate the future value based on the amount, maturityDate interestRate and recoveryRate
+    /// @param loanInterestRate the interest rate of the loan
+    /// @param amount of the loan (principal)
+    /// @param maturityDate the maturity date of the loan
+    /// @param recoveryRatePD the recovery rate together with the probability of default of the loan
+    /// @return fv future value of the loan
+    function calcFutureValue(uint256 loanInterestRate, uint256 amount, uint256 maturityDate, uint256 recoveryRatePD)
         public
         view
-        returns (uint256)
+        returns (uint256 fv)
     {
         uint256 nnow = uniqueDayTimestamp(block.timestamp);
         uint256 timeRemaining = 0;
-        if (maturityDate_ > nnow) {
-            timeRemaining = safeSub(maturityDate_, nnow);
+        if (maturityDate > nnow) {
+            timeRemaining = safeSub(maturityDate, nnow);
         }
 
-        return rmul(rmul(rpow(loanInterestRate, timeRemaining, ONE), amount), recoveryRatePD_);
+        return rmul(rmul(rpow(loanInterestRate, timeRemaining, ONE), amount), recoveryRatePD);
     }
 
-    function secureSub(uint256 x, uint256 y) public pure returns (uint256) {
+    /// @notice substracts to values if the result smaller than 0 it returns 0
+    /// @param x the first value (minuend)
+    /// @param y the second value (subtrahend)
+    /// @return result result of the subtraction
+    function secureSub(uint256 x, uint256 y) public pure returns (uint256 result) {
         if (y > x) {
             return 0;
         }
         return safeSub(x, y);
     }
 
-    // normalizes a timestamp to round down to the nearest midnight (UTC)
-    function uniqueDayTimestamp(uint256 timestamp) public pure returns (uint256) {
+    /// @notice normalizes a timestamp to round down to the nearest midnight (UTC)
+    /// @param timestamp the timestamp which should be normalized
+    /// @return nTimstamp normalized timestamp
+    function uniqueDayTimestamp(uint256 timestamp) public pure returns (uint256 nTimstamp) {
         return (1 days) * (timestamp / (1 days));
     }
+    /// @notice rpow peforms a math pow operation with fixed point number
+    /// adopted from ds-math
+    /// @param x the base for the pow operation
+    /// @param n the exponent for the pow operation
+    /// @param base the base of the fixed point number
+    /// @return z the result of the pow operation
 
     function rpow(uint256 x, uint256 n, uint256 base) public pure returns (uint256 z) {
         assembly {

--- a/src/borrower/feed/navfeed.sol
+++ b/src/borrower/feed/navfeed.sol
@@ -121,7 +121,7 @@ contract NAVFeed is Auth, Discounting {
     function maturityDate(bytes32 nft_) public view returns (uint256 maturityDate_) {
         return uint256(details[nft_].maturityDate);
     }
-    /// @notice getter functiion for the risk group
+    /// @notice getter function for the risk group
     /// @param nft_ the id of the nft based on the hash of registry and tokenId
     /// @return risk_ the risk group of the nft
 

--- a/src/borrower/feed/navfeed.sol
+++ b/src/borrower/feed/navfeed.sol
@@ -22,18 +22,19 @@ interface PileLike {
     function rateDebt(uint256 rate) external view returns (uint256);
 }
 
-// The NAV Feed contract calculates the Net Asset Value of a Tinlake pool.
-// NAV is computed as the sum of all discounted future values (fv) of ongoing loans (debt > 0) in the pool.
-// The applied discountRate is dependant on the maturity data of the underlying collateral.
-// The discount decreases with the maturity date approaching.
-// To optimize the NAV calculation, the NAV is calculated as the change in discounted future values since the calculation.
-// When loans are overdue, they are locked at their fv on the maturity date.
-// They can then be written off, using the public writeoff method based on
-// the default writeoff schedule, or using the override writeoff method.
+/// @notice NAVFeed contract calculates the Net Asset Value of a Tinlake pool.
+/// NAV is computed as the sum of all discounted future values (fv) of ongoing loans (debt > 0) in the pool.
+/// The applied discountRate is dependant on the maturity data of the underlying collateral.
+/// The discount decreases with the maturity date approaching.
+/// To optimize the NAV calculation, the NAV is calculated as the change in discounted future values
+/// since the calculation. When loans are overdue, they are locked at their fv on the maturity date.
+/// They can then be written off, using the public writeoff method based on
+/// the default writeoff schedule, or using the override writeoff method.
 contract NAVFeed is Auth, Discounting {
     PileLike public pile;
     ShelfLike public shelf;
 
+    /// @notice details of the underlying collateral
     struct NFTDetails {
         uint128 nftValues;
         uint128 futureValue;
@@ -41,6 +42,7 @@ contract NAVFeed is Auth, Discounting {
         uint128 risk;
     }
 
+    /// @notice risk group details
     struct RiskGroup {
         // denominated in (10^27)
         uint128 ceilingRatio;
@@ -50,12 +52,14 @@ contract NAVFeed is Auth, Discounting {
         uint128 recoveryRatePD;
     }
 
+    /// @notice details of the loan
     struct LoanDetails {
         uint128 borrowed;
         // only auth calls can move loan into different writeOff group
         bool authWriteOff;
     }
 
+    /// @notice details of the write off group
     struct WriteOffGroup {
         // denominated in (10^27)
         uint128 percentage;
@@ -111,36 +115,59 @@ contract NAVFeed is Auth, Discounting {
     event File(bytes32 indexed name, uint256 rate_, uint256 writeOffPercentage_, uint256 overdueDays_);
     event WriteOff(uint256 indexed loan, uint256 indexed writeOffGroupsIndex, bool override_);
 
-    // getter functions
-    function maturityDate(bytes32 nft_) public view returns (uint256) {
+    /// @notice getter function for the maturityDate
+    /// @param nft_ the id of the nft based on the hash of registry and tokenId
+    /// @return maturityDate_ the maturityDate of the nft
+    function maturityDate(bytes32 nft_) public view returns (uint256 maturityDate_) {
         return uint256(details[nft_].maturityDate);
     }
+    /// @notice getter functiion for the risk group
+    /// @param nft_ the id of the nft based on the hash of registry and tokenId
+    /// @return risk_ the risk group of the nft
 
-    function risk(bytes32 nft_) public view returns (uint256) {
+    function risk(bytes32 nft_) public view returns (uint256 risk_) {
         return uint256(details[nft_].risk);
     }
+    /// @notice getter function for the nft value
+    /// @param nft_ the id of the nft based on the hash of registry and tokenId
+    /// @return nftValue_ the value of the nft
 
-    function nftValues(bytes32 nft_) public view returns (uint256) {
+    function nftValues(bytes32 nft_) public view returns (uint256 nftValue_) {
         return uint256(details[nft_].nftValues);
     }
 
-    function futureValue(bytes32 nft_) public view returns (uint256) {
+    /// @notice getter function for the future value
+    /// @param nft_ the id of the nft based on the hash of registry and tokenId
+    /// @return fv_ future value of the loan
+    function futureValue(bytes32 nft_) public view returns (uint256 fv_) {
         return uint256(details[nft_].futureValue);
     }
+    /// @notice getter function for the ceiling Ratio
+    /// @param riskID id of a risk group
+    /// @return ceilingRatio_ the ceiling ratio of the risk group
 
-    function ceilingRatio(uint256 riskID) public view returns (uint256) {
+    function ceilingRatio(uint256 riskID) public view returns (uint256 ceilingRatio_) {
         return uint256(riskGroup[riskID].ceilingRatio);
     }
 
-    function thresholdRatio(uint256 riskID) public view returns (uint256) {
+    /// @notice getter function for the threshold Ratio
+    /// @param riskID id of a risk group
+    /// @return thresholdRatio_ threshold ratio of the risk group
+    function thresholdRatio(uint256 riskID) public view returns (uint256 thresholdRatio_) {
         return uint256(riskGroup[riskID].thresholdRatio);
     }
 
-    function recoveryRatePD(uint256 riskID) public view returns (uint256) {
+    /// @notice getter function for the recovery rate PD
+    /// @param riskID id of a risk group
+    /// @return recoveryRatePD_ recovery rate PD of the risk group
+    function recoveryRatePD(uint256 riskID) public view returns (uint256 recoveryRatePD_) {
         return uint256(riskGroup[riskID].recoveryRatePD);
     }
 
-    function borrowed(uint256 loan) public view returns (uint256) {
+    /// @notice getter function for the borrowed amount
+    /// @param loan id of a loan
+    /// @return borrowed_ borrowed amount of the loan
+    function borrowed(uint256 loan) public view returns (uint256 borrowed_) {
         return uint256(loanDetails[loan].borrowed);
     }
 
@@ -150,14 +177,19 @@ contract NAVFeed is Auth, Discounting {
         emit Rely(msg.sender);
     }
 
-    function toUint128(uint256 value) internal pure returns (uint128) {
+    /// @notice converts a uint256 to uint128
+    /// @param value the value to be converted
+    /// @return converted value to uint128
+    function toUint128(uint256 value) internal pure returns (uint128 converted) {
         require(value <= type(uint128).max, "SafeCast: value doesn't fit in 128 bits");
         return uint128(value);
     }
 
-    // returns the ceiling of a loan
-    // the ceiling defines the maximum amount which can be borrowed
-    function ceiling(uint256 loan) public view virtual returns (uint256) {
+    /// @notice returns the ceiling of a loan
+    /// the ceiling defines the maximum amount which can be borrowed
+    /// @param loan the id of the loan
+    /// @return ceiling_ the ceiling of the loan
+    function ceiling(uint256 loan) public view virtual returns (uint256 ceiling_) {
         bytes32 nftID_ = nftID(loan);
         uint256 initialCeiling = rmul(nftValues(nftID_), ceilingRatio(risk(nftID_)));
 
@@ -168,7 +200,9 @@ contract NAVFeed is Auth, Discounting {
         return safeSub(initialCeiling, borrowed(loan));
     }
 
-    // --- Administration ---
+    /// @notice depend wires contract dependencies together
+    /// @param contractName id of a contract dependency
+    /// @param addr address of the contract dependency
     function depend(bytes32 contractName, address addr) external auth {
         if (contractName == "pile") pile = PileLike(addr);
         else if (contractName == "shelf") shelf = ShelfLike(addr);
@@ -176,23 +210,34 @@ contract NAVFeed is Auth, Discounting {
         emit Depend(contractName, addr);
     }
 
+    /// @notice file allows governance to change parameters of the contract
+    /// @param name name of the parameter group
+    /// @param risk_ id of new risk group
+    /// @param thresholdRatio_ new threshold ratio
+    /// @param ceilingRatio_ new ceiling ratio
+    /// @param interestRate_ new interest rate of the risk group
+    /// @param recoveryRatePD_ new recovery rate PD of the risk group
     function file(
         bytes32 name,
         uint256 risk_,
         uint256 thresholdRatio_,
         uint256 ceilingRatio_,
-        uint256 rate_,
+        uint256 interestRate_,
         uint256 recoveryRatePD_
     ) public auth {
         if (name == "riskGroup") {
-            file("riskGroupNFT", risk_, thresholdRatio_, ceilingRatio_, rate_);
+            file("riskGroupNFT", risk_, thresholdRatio_, ceilingRatio_, interestRate_);
             riskGroup[risk_].recoveryRatePD = toUint128(recoveryRatePD_);
-            emit File(name, risk_, thresholdRatio_, ceilingRatio_, rate_, recoveryRatePD_);
+            emit File(name, risk_, thresholdRatio_, ceilingRatio_, interestRate_, recoveryRatePD_);
         } else {
             revert("unknown name");
         }
     }
 
+    /// @notice file allows governance to change parameters of the contract
+    /// @param name name of the parameter group
+    /// @param nftID_ the nft id of the nft
+    /// @param maturityDate_ the maturity date of the nft
     function file(bytes32 name, bytes32 nftID_, uint256 maturityDate_) public auth {
         // maturity date only can be changed when there is no debt on the collateral -> futureValue == 0
         if (name == "maturityDate") {
@@ -204,6 +249,9 @@ contract NAVFeed is Auth, Discounting {
         }
     }
 
+    /// @notice file allows governance to change parameters of the contract
+    /// @param name name of the parameter
+    /// @param value new value of the parameter
     function file(bytes32 name, uint256 value) public auth {
         if (name == "discountRate") {
             uint256 oldDiscountRate = discountRate;
@@ -219,7 +267,13 @@ contract NAVFeed is Auth, Discounting {
         }
     }
 
-    function file(bytes32 name, uint256 risk_, uint256 thresholdRatio_, uint256 ceilingRatio_, uint256 rate_)
+    /// @notice file allows governance to change parameters of the contract
+    /// @param name name of the parameter group
+    /// @param risk_ id of new risk group
+    /// @param thresholdRatio_ new threshold ratio
+    /// @param ceilingRatio_ new ceiling ratio
+    /// @param interestRate_ new interest rate of the risk group
+    function file(bytes32 name, uint256 risk_, uint256 thresholdRatio_, uint256 ceilingRatio_, uint256 interestRate_)
         public
         auth
     {
@@ -229,13 +283,17 @@ contract NAVFeed is Auth, Discounting {
             riskGroup[risk_].ceilingRatio = toUint128(ceilingRatio_);
 
             // set interestRate for risk group
-            pile.file("rate", risk_, rate_);
-            emit File(name, risk_, thresholdRatio_, ceilingRatio_, rate_);
+            pile.file("rate", risk_, interestRate_);
+            emit File(name, risk_, thresholdRatio_, ceilingRatio_, interestRate_);
         } else {
             revert("unknown name");
         }
     }
 
+    /// @notice file allows governance to change parameters of the contract
+    /// @param name name of the parameter group
+    /// @param writeOffPercentage_ the write off rate in percent
+    /// @param overdueDays_ the number of days after which a loan is considered overdue
     function file(bytes32 name, uint256 rate_, uint256 writeOffPercentage_, uint256 overdueDays_) public auth {
         if (name == "writeOffGroup") {
             uint256 index = writeOffGroups.length;
@@ -247,7 +305,10 @@ contract NAVFeed is Auth, Discounting {
         }
     }
 
-    // --- Actions ---
+    /// @notice borrow updates the NAV for a new borrowed loan
+    /// @param loan the id of the loan
+    /// @param amount the amount borrowed
+    /// @return navIncrease the increase of the NAV impacted by the new borrow
     function borrow(uint256 loan, uint256 amount) external virtual auth returns (uint256 navIncrease) {
         uint256 nnow = uniqueDayTimestamp(block.timestamp);
         bytes32 nftID_ = nftID(loan);
@@ -283,6 +344,9 @@ contract NAVFeed is Auth, Discounting {
         return navIncrease;
     }
 
+    /// @notice repay updates the NAV for a new repaid loan
+    /// @param loan the id of the loan
+    /// @param amount the amount repaid
     function repay(uint256 loan, uint256 amount) external virtual auth {
         uint256 nnow = uniqueDayTimestamp(block.timestamp);
         if (nnow > lastNAVUpdate) {
@@ -333,6 +397,8 @@ contract NAVFeed is Auth, Discounting {
         }
     }
 
+    /// @notice borrowEvent triggers a borrow event for a loan
+    /// @param loan the id of the loan
     function borrowEvent(uint256 loan, uint256) public virtual auth {
         uint256 risk_ = risk(nftID(loan));
 
@@ -348,6 +414,8 @@ contract NAVFeed is Auth, Discounting {
     function lockEvent(uint256 loan) public virtual auth {}
     function unlockEvent(uint256 loan) public virtual auth {}
 
+    /// @notice writeOff writes off a loan if it is overdue
+    /// @param loan the id of the loan
     function writeOff(uint256 loan) public {
         require(!loanDetails[loan].authWriteOff, "only-auth-write-off");
 
@@ -370,6 +438,9 @@ contract NAVFeed is Auth, Discounting {
         }
     }
 
+    /// @notice authorized call to write of a loan in a specific writeoff group
+    /// @param loan the id of the loan
+    /// @param writeOffGroupIndex_ the index of the writeoff group
     function overrideWriteOff(uint256 loan, uint256 writeOffGroupIndex_) public auth {
         // can not write-off healthy loans
         bytes32 nftID_ = nftID(loan);
@@ -384,6 +455,11 @@ contract NAVFeed is Auth, Discounting {
         emit WriteOff(loan, writeOffGroupIndex_, true);
     }
 
+    /// @notice internal function for the write off
+    /// @param loan the id of the loan
+    /// @param writeOffGroupIndex_ the index of the writeoff group
+    /// @param nftID_ the nftID of the loan
+    /// @param maturityDate_ the maturity date of the loan
     function _writeOff(uint256 loan, uint256 writeOffGroupIndex_, bytes32 nftID_, uint256 maturityDate_) internal {
         uint256 nnow = uniqueDayTimestamp(block.timestamp);
         // Ensure we have an up to date NAV
@@ -413,16 +489,23 @@ contract NAVFeed is Auth, Discounting {
         latestNAV = safeAdd(latestNAV_, rmul(pile.debt(loan), writeOffGroups[writeOffGroupIndex_].percentage));
     }
 
+    /// @notice returns if a loan is written off
+    /// @param loan the id of the loan
     function isLoanWrittenOff(uint256 loan) public view returns (bool) {
         return pile.loanRates(loan) >= WRITEOFF_RATE_GROUP_START;
     }
 
-    // --- NAV calculation ---
-    function currentNAV() public view returns (uint256) {
+    /// @notice calculates and returns the current NAV
+    /// @return nav_ current NAV
+    function currentNAV() public view returns (uint256 nav_) {
         (uint256 totalDiscount, uint256 overdue, uint256 writeOffs) = currentPVs();
         return safeAdd(totalDiscount, safeAdd(overdue, writeOffs));
     }
 
+    /// @notice calculates the present value of the loans together with overdue and written off loans
+    /// @return totalDiscount the present value of the loans
+    /// @return overdue the present value of the overdue loans
+    /// @return writeOffs the present value of the written off loans
     function currentPVs() public view returns (uint256 totalDiscount, uint256 overdue, uint256 writeOffs) {
         if (latestDiscount == 0) {
             // all loans are overdue or writtenOff
@@ -454,8 +537,9 @@ contract NAVFeed is Auth, Discounting {
         );
     }
 
-    function currentWriteOffs() public view returns (uint256) {
-        uint256 sum = 0;
+    /// @notice returns the sum of all write off loans
+    /// @return sum of all write off loans
+    function currentWriteOffs() public view returns (uint256 sum) {
         for (uint256 i = 0; i < writeOffGroups.length; i++) {
             // multiply writeOffGroupDebt with the writeOff rate
             sum =
@@ -464,7 +548,9 @@ contract NAVFeed is Auth, Discounting {
         return sum;
     }
 
-    function calcUpdateNAV() public returns (uint256) {
+    /// @notice calculates and returns the current NAV and updates the state
+    /// @return nav_ current NAV
+    function calcUpdateNAV() public returns (uint256 nav_) {
         (uint256 totalDiscount, uint256 overdue, uint256 writeOffs) = currentPVs();
 
         overdueLoans = overdue;
@@ -475,9 +561,10 @@ contract NAVFeed is Auth, Discounting {
         return latestNAV;
     }
 
-    // re-calculates the nav in a non-optimized way
-    // the method is not updating the NAV to latest block.timestamp
-    function reCalcNAV() public returns (uint256) {
+    /// @notice re-calculates the nav in a non-optimized way
+    ///  the method is not updating the NAV to latest block.timestamp
+    /// @return nav_ current NAV
+    function reCalcNAV() public returns (uint256 nav_) {
         uint256 latestDiscount_ = reCalcTotalDiscount();
 
         latestNAV = safeAdd(latestDiscount_, safeSub(latestNAV, latestDiscount));
@@ -485,9 +572,10 @@ contract NAVFeed is Auth, Discounting {
         return latestNAV;
     }
 
-    // re-calculates the totalDiscount in a non-optimized way based on lastNAVUpdate
-    function reCalcTotalDiscount() public view returns (uint256) {
-        uint256 latestDiscount_ = 0;
+    /// @notice re-calculates the totalDiscount in a non-optimized way based on lastNAVUpdate
+    /// @return latestDiscount_ returns the total discount of the active loans
+    function reCalcTotalDiscount() public view returns (uint256 latestDiscount_) {
+        latestDiscount_ = 0;
 
         for (uint256 loanID = 1; loanID < shelf.loanCount(); loanID++) {
             bytes32 nftID_ = nftID(loanID);
@@ -503,12 +591,17 @@ contract NAVFeed is Auth, Discounting {
         return latestDiscount_;
     }
 
+    /// @notice update the value (apprasial) of the collateral NFT
     function update(bytes32 nftID_, uint256 value) public auth {
         // switch of collateral risk group results in new: ceiling, threshold for existing loan
         details[nftID_].nftValues = toUint128(value);
         emit Update(nftID_, value);
     }
 
+    /// @notice updates the risk group of active loans (borrowed and unborrowed loans)
+    /// @param nftID_ the nftID of the loan
+    /// @param risk_ the new value appraisal of the collateral NFT
+    /// @param risk_ the new risk group
     function update(bytes32 nftID_, uint256 value, uint256 risk_) public auth {
         uint256 nnow = uniqueDayTimestamp(block.timestamp);
         details[nftID_].nftValues = toUint128(value);
@@ -566,28 +659,37 @@ contract NAVFeed is Auth, Discounting {
     }
 
     // --- Utilities ---
-    // returns the threshold of a loan
-    // if the loan debt is above the loan threshold the NFT can be seized
-    function threshold(uint256 loan) public view returns (uint256) {
+    /// @notice returns the threshold of a loan
+    /// if the loan debt is above the loan threshold the NFT can be seized
+    /// @param loan the id of the loan
+    /// @return threshold_ the threshold of the loan
+    function threshold(uint256 loan) public view returns (uint256 threshold_) {
         bytes32 nftID_ = nftID(loan);
         return rmul(nftValues(nftID_), thresholdRatio(risk(nftID_)));
     }
 
-    // returns a unique id based on the nft registry and tokenId
-    // the nftID is used to set the risk group and value for nfts
-    function nftID(address registry, uint256 tokenId) public pure returns (bytes32) {
+    /// @notice returns a unique id based on the nft registry and tokenId
+    /// the nftID is used to set the risk group and value for nfts
+    /// @param registry the address of the nft registry
+    /// @param tokenId the tokenId of the nft
+    /// @return nftID_ the nftID of the nft
+    function nftID(address registry, uint256 tokenId) public pure returns (bytes32 nftID_) {
         return keccak256(abi.encodePacked(registry, tokenId));
     }
 
-    // returns the nftID for the underlying collateral nft
-    function nftID(uint256 loan) public view returns (bytes32) {
+    /// @notice returns the nftID for the underlying collateral nft
+    /// @param loan the loan id
+    /// @return nftID_ the nftID of the loan
+    function nftID(uint256 loan) public view returns (bytes32 nftID_) {
         (address registry, uint256 tokenId) = shelf.shelf(loan);
         return nftID(registry, tokenId);
     }
 
-    // returns true if the present value of a loan is zero
-    // true if all debt is repaid or debt is 100% written-off
-    function zeroPV(uint256 loan) public view returns (bool) {
+    /// @notice returns true if the present value of a loan is zero
+    /// true if all debt is repaid or debt is 100% written-off
+    /// @param loan the loan id
+    /// @return isZeroPV true if the present value of a loan is zero
+    function zeroPV(uint256 loan) public view returns (bool isZeroPV) {
         if (pile.debt(loan) == 0) {
             return true;
         }
@@ -601,7 +703,10 @@ contract NAVFeed is Auth, Discounting {
         return writeOffGroups[safeSub(rate, WRITEOFF_RATE_GROUP_START)].percentage == 0;
     }
 
-    function currentValidWriteOffGroup(uint256 loan) public view returns (uint256) {
+    /// @notice returns the current valid write off group of a loan
+    /// @param loan the loan id
+    /// @return writeOffGroup_ the current valid write off group of a loan
+    function currentValidWriteOffGroup(uint256 loan) public view returns (uint256 writeOffGroup_) {
         bytes32 nftID_ = nftID(loan);
         uint256 maturityDate_ = maturityDate(nftID_);
         uint256 nnow = uniqueDayTimestamp(block.timestamp);

--- a/src/borrower/pile.sol
+++ b/src/borrower/pile.sol
@@ -161,7 +161,7 @@ contract Pile is Auth, Interest {
         emit ChangeRate(loan, newRate);
     }
 
-    /// @notice accrue needs to be called before any debt amounts are modified by an external component
+    /// @notice calls drip on the given loan
     /// @param loan the id of the loan
     function accrue(uint256 loan) external {
         drip(loanRates[loan]);

--- a/src/borrower/pile.sol
+++ b/src/borrower/pile.sol
@@ -6,8 +6,9 @@ import "tinlake-math/interest.sol";
 import "tinlake-auth/auth.sol";
 
 /// @notice Pile Contract to manage different interest groups of debt
-/// The following is one implementation of a debt module. It keeps track of different buckets of interest rates and is optimized for many loans per interest bucket. It keeps track of interest
-/// rate accumulators (chi values) for all interest rate categories. It calculates debt each
+/// The following is one implementation of a debt module.
+/// It keeps track of different buckets of interest rates and is optimized for many loans per interest bucket.
+/// Each bucket holds it own rate accumulators (chi values). It calculates debt for each
 /// loan according to its interest rate category and pie value.
 contract Pile is Auth, Interest {
     /// @notice stores all needed information of an interest rate group

--- a/src/borrower/pile.sol
+++ b/src/borrower/pile.sol
@@ -10,6 +10,20 @@ import "tinlake-auth/auth.sol";
 /// rate accumulators (chi values) for all interest rate categories. It calculates debt each
 /// loan according to its interest rate category and pie value.
 contract Pile is Auth, Interest {
+    /// @notice stores all needed information of an interest rate group
+    struct Rate {
+        // total debt of all loans with this rate
+        uint256 pie;
+        // accumlated rate index over time
+        uint256 chi;
+        // interest rate per second
+        uint256 ratePerSecond;
+        // last time the rate was accumulated
+        uint48 lastUpdated;
+        // fixed rate applied to each loan of the group
+        uint256 fixedRate;
+    }
+
     /// @notice Interest Rate Groups are identified by a `uint` and stored in a mapping
     mapping(uint256 => Rate) public rates;
 
@@ -95,8 +109,8 @@ contract Pile is Auth, Interest {
 
     /// @notice returns the current debt based on actual block.timestamp (now)
     /// @param loan the id of the loan
-    /// @return the debt of the loan
-    function debt(uint256 loan) external view returns (uint256 debt) {
+    /// @return loanDebt debt of the loan
+    function debt(uint256 loan) external view returns (uint256 loanDebt) {
         uint256 rate_ = loanRates[loan];
         uint256 chi_ = rates[rate_].chi;
         if (block.timestamp >= rates[rate_].lastUpdated) {
@@ -107,7 +121,7 @@ contract Pile is Auth, Interest {
 
     /// @notice returns the total debt of a interest rate group
     /// @param rate the id of the interest rate group
-    /// @return the total debt of the interest rate group
+    /// @return totalDebt total debt of the interest rate group
     function rateDebt(uint256 rate) external view returns (uint256 totalDebt) {
         uint256 chi_ = rates[rate].chi;
         uint256 pie_ = rates[rate].pie;

--- a/src/borrower/pile.sol
+++ b/src/borrower/pile.sol
@@ -5,34 +5,24 @@ pragma solidity >=0.7.6;
 import "tinlake-math/interest.sol";
 import "tinlake-auth/auth.sol";
 
-// ## Interest Group based Pile
-// The following is one implementation of a debt module. It keeps track of different buckets of interest rates and is optimized for many loans per interest bucket. It keeps track of interest
-// rate accumulators (chi values) for all interest rate categories. It calculates debt each
-// loan according to its interest rate category and pie value.
+/// @notice Pile Contract to manage different interest groups of debt
+/// The following is one implementation of a debt module. It keeps track of different buckets of interest rates and is optimized for many loans per interest bucket. It keeps track of interest
+/// rate accumulators (chi values) for all interest rate categories. It calculates debt each
+/// loan according to its interest rate category and pie value.
 contract Pile is Auth, Interest {
-    // --- Data ---
-
-    // stores all needed information of an interest rate group
-    struct Rate {
-        uint256 pie; // Total debt of all loans with this rate
-        uint256 chi; // Accumulated rates
-        uint256 ratePerSecond; // Accumulation per second
-        uint48 lastUpdated; // Last time the rate was accumulated
-        uint256 fixedRate; // fixed rate applied to each loan of the group
-    }
-
-    // Interest Rate Groups are identified by a `uint` and stored in a mapping
+    /// @notice Interest Rate Groups are identified by a `uint` and stored in a mapping
     mapping(uint256 => Rate) public rates;
 
-    // mapping of all loan debts
-    // the debt is stored as pie
-    // pie is defined as pie = debt/chi therefore debt = pie * chi
-    // where chi is the accumulated interest rate index over time
+    /// @notice mapping of all loan debts
+    /// the debt is stored as pie
+    /// pie is defined as pie = debt/chi therefore debt = pie * chi
+    /// where chi is the accumulated interest rate index over time
     mapping(uint256 => uint256) public pie;
-    // loan => rate
+
+    /// @notice mapping from loan => rate
     mapping(uint256 => uint256) public loanRates;
 
-    // Events
+    /// Events
     event IncreaseDebt(uint256 indexed loan, uint256 currencyAmount);
     event DecreaseDebt(uint256 indexed loan, uint256 currencyAmount);
     event SetRate(uint256 indexed loan, uint256 rate);
@@ -48,82 +38,11 @@ contract Pile is Auth, Interest {
         emit Rely(msg.sender);
     }
 
-    // --- Public Debt Methods  ---
-    // increases the debt of a loan by a currencyAmount
-    // a change of the loan debt updates the rate debt and total debt
-    function incDebt(uint256 loan, uint256 currencyAmount) external auth {
-        uint256 rate = loanRates[loan];
-        require(block.timestamp == rates[rate].lastUpdated, "rate-group-not-updated");
-        currencyAmount = safeAdd(currencyAmount, rmul(currencyAmount, rates[rate].fixedRate));
-        uint256 pieAmount = toPie(rates[rate].chi, currencyAmount);
-
-        pie[loan] = safeAdd(pie[loan], pieAmount);
-        rates[rate].pie = safeAdd(rates[rate].pie, pieAmount);
-
-        emit IncreaseDebt(loan, currencyAmount);
-    }
-
-    // decrease the loan's debt by a currencyAmount
-    // a change of the loan debt updates the rate debt and total debt
-    function decDebt(uint256 loan, uint256 currencyAmount) external auth {
-        uint256 rate = loanRates[loan];
-        require(block.timestamp == rates[rate].lastUpdated, "rate-group-not-updated");
-        uint256 pieAmount = toPie(rates[rate].chi, currencyAmount);
-
-        pie[loan] = safeSub(pie[loan], pieAmount);
-        rates[rate].pie = safeSub(rates[rate].pie, pieAmount);
-
-        emit DecreaseDebt(loan, currencyAmount);
-    }
-
-    // returns the current debt based on actual block.timestamp (now)
-    function debt(uint256 loan) external view returns (uint256) {
-        uint256 rate_ = loanRates[loan];
-        uint256 chi_ = rates[rate_].chi;
-        if (block.timestamp >= rates[rate_].lastUpdated) {
-            chi_ = chargeInterest(rates[rate_].chi, rates[rate_].ratePerSecond, rates[rate_].lastUpdated);
-        }
-        return toAmount(chi_, pie[loan]);
-    }
-
-    // returns the total debt of a interest rate group
-    function rateDebt(uint256 rate) external view returns (uint256) {
-        uint256 chi_ = rates[rate].chi;
-        uint256 pie_ = rates[rate].pie;
-
-        if (block.timestamp >= rates[rate].lastUpdated) {
-            chi_ = chargeInterest(rates[rate].chi, rates[rate].ratePerSecond, rates[rate].lastUpdated);
-        }
-        return toAmount(chi_, pie_);
-    }
-
-    // --- Interest Rate Group Implementation ---
-
-    // set rate loanRates for a loan
-    function setRate(uint256 loan, uint256 rate) external auth {
-        require(pie[loan] == 0, "non-zero-debt");
-        // rate category has to be initiated
-        require(rates[rate].chi != 0, "rate-group-not-set");
-        loanRates[loan] = rate;
-        emit SetRate(loan, rate);
-    }
-
-    // change rate loanRates for a loan
-    function changeRate(uint256 loan, uint256 newRate) external auth {
-        require(rates[newRate].chi != 0, "rate-group-not-set");
-        uint256 currentRate = loanRates[loan];
-        drip(currentRate);
-        drip(newRate);
-        uint256 pie_ = pie[loan];
-        uint256 debt_ = toAmount(rates[currentRate].chi, pie_);
-        rates[currentRate].pie = safeSub(rates[currentRate].pie, pie_);
-        pie[loan] = toPie(rates[newRate].chi, debt_);
-        rates[newRate].pie = safeAdd(rates[newRate].pie, pie[loan]);
-        loanRates[loan] = newRate;
-        emit ChangeRate(loan, newRate);
-    }
-
-    // set/change the interest rate of a rate category
+    /// @notice file manages different state configs for the pile
+    /// only a ward can call this function
+    /// @param what what config to change
+    /// @param rate the interest rate group
+    /// @param value the value to change
     function file(bytes32 what, uint256 rate, uint256 value) external auth {
         if (what == "rate") {
             require(value != 0, "rate-per-second-can-not-be-0");
@@ -143,13 +62,98 @@ contract Pile is Auth, Interest {
         emit File(what, rate, value);
     }
 
-    // accrue needs to be called before any debt amounts are modified by an external component
+    /// @notice increases the debt of a loan by a currencyAmount
+    /// a change of the loan debt updates the rate debt and total debt
+    /// @param loan the id of the loan
+    /// @param currencyAmount the amount of currency to be added to the loan debt
+    function incDebt(uint256 loan, uint256 currencyAmount) external auth {
+        uint256 rate = loanRates[loan];
+        require(block.timestamp == rates[rate].lastUpdated, "rate-group-not-updated");
+        currencyAmount = safeAdd(currencyAmount, rmul(currencyAmount, rates[rate].fixedRate));
+        uint256 pieAmount = toPie(rates[rate].chi, currencyAmount);
+
+        pie[loan] = safeAdd(pie[loan], pieAmount);
+        rates[rate].pie = safeAdd(rates[rate].pie, pieAmount);
+
+        emit IncreaseDebt(loan, currencyAmount);
+    }
+
+    /// @notice decrease the loan's debt by a currencyAmount
+    /// a change of the loan debt updates the rate debt and total debt
+    /// @param loan the id of the loan
+    /// @param currencyAmount the amount of currency to be removed from the loan debt
+    function decDebt(uint256 loan, uint256 currencyAmount) external auth {
+        uint256 rate = loanRates[loan];
+        require(block.timestamp == rates[rate].lastUpdated, "rate-group-not-updated");
+        uint256 pieAmount = toPie(rates[rate].chi, currencyAmount);
+
+        pie[loan] = safeSub(pie[loan], pieAmount);
+        rates[rate].pie = safeSub(rates[rate].pie, pieAmount);
+
+        emit DecreaseDebt(loan, currencyAmount);
+    }
+
+    /// @notice returns the current debt based on actual block.timestamp (now)
+    /// @param loan the id of the loan
+    /// @return the debt of the loan
+    function debt(uint256 loan) external view returns (uint256 debt) {
+        uint256 rate_ = loanRates[loan];
+        uint256 chi_ = rates[rate_].chi;
+        if (block.timestamp >= rates[rate_].lastUpdated) {
+            chi_ = chargeInterest(rates[rate_].chi, rates[rate_].ratePerSecond, rates[rate_].lastUpdated);
+        }
+        return toAmount(chi_, pie[loan]);
+    }
+
+    /// @notice returns the total debt of a interest rate group
+    /// @param rate the id of the interest rate group
+    /// @return the total debt of the interest rate group
+    function rateDebt(uint256 rate) external view returns (uint256 totalDebt) {
+        uint256 chi_ = rates[rate].chi;
+        uint256 pie_ = rates[rate].pie;
+
+        if (block.timestamp >= rates[rate].lastUpdated) {
+            chi_ = chargeInterest(rates[rate].chi, rates[rate].ratePerSecond, rates[rate].lastUpdated);
+        }
+        return toAmount(chi_, pie_);
+    }
+
+    /// @notice set rate loanRates for a loan
+    /// @param loan the id of the loan
+    /// @param rate the id of the interest rate group
+    function setRate(uint256 loan, uint256 rate) external auth {
+        require(pie[loan] == 0, "non-zero-debt");
+        // rate category has to be initiated
+        require(rates[rate].chi != 0, "rate-group-not-set");
+        loanRates[loan] = rate;
+        emit SetRate(loan, rate);
+    }
+
+    /// @notice change rate loanRates for a loan
+    /// @param loan the id of the loan
+    /// @param newRate the id ofthe new interest rate group
+    function changeRate(uint256 loan, uint256 newRate) external auth {
+        require(rates[newRate].chi != 0, "rate-group-not-set");
+        uint256 currentRate = loanRates[loan];
+        drip(currentRate);
+        drip(newRate);
+        uint256 pie_ = pie[loan];
+        uint256 debt_ = toAmount(rates[currentRate].chi, pie_);
+        rates[currentRate].pie = safeSub(rates[currentRate].pie, pie_);
+        pie[loan] = toPie(rates[newRate].chi, debt_);
+        rates[newRate].pie = safeAdd(rates[newRate].pie, pie[loan]);
+        loanRates[loan] = newRate;
+        emit ChangeRate(loan, newRate);
+    }
+
+    /// @notice accrue needs to be called before any debt amounts are modified by an external component
+    /// @param loan the id of the loan
     function accrue(uint256 loan) external {
         drip(loanRates[loan]);
     }
 
-    // drip updates the chi of the rate category by compounding the interest and
-    // updates the total debt
+    /// @notice drip updates the chi of the rate category by compounding the interest
+    /// @param rate the id of the interest rate group
     function drip(uint256 rate) public {
         if (block.timestamp >= rates[rate].lastUpdated) {
             (uint256 chi,) =

--- a/src/borrower/shelf.sol
+++ b/src/borrower/shelf.sol
@@ -192,7 +192,7 @@ contract Shelf is Auth, TitleOwned, Math {
         emit Borrow(loan, currencyAmount);
     }
 
-    /// @notice withdraw transfers the acutal currency to the borrower account
+    /// @notice withdraw transfers the actual currency to the borrower account
     /// @param loan the id of the loan
     /// @param currencyAmount the amount which should be withdrawn
     /// @param usr the address of the receiver
@@ -258,7 +258,7 @@ contract Shelf is Auth, TitleOwned, Math {
     }
 
     /// @notice locks an nft in the shelf
-    /// requires an issued loan
+    /// @dev requires an issued loan
     /// @param loan the id of the loan
     function lock(uint256 loan) external owner(loan) {
         if (address(subscriber) != address(0)) {
@@ -269,7 +269,7 @@ contract Shelf is Auth, TitleOwned, Math {
     }
 
     /// @notice unlocks an nft in the shelf
-    /// requires zero debt or 100% write off
+    /// @dev requires zero debt or 100% write off
     /// @param loan the id of the loan
     function unlock(uint256 loan) external owner(loan) {
         // loans can be unlocked and closed when the debt is 0, or the loan is written off 100%

--- a/src/borrower/shelf.sol
+++ b/src/borrower/shelf.sol
@@ -52,7 +52,7 @@ interface AssessorLike {
 }
 
 contract Shelf is Auth, TitleOwned, Math {
-    // --- Data ---
+    /// Contract Interfaces
     NAVFeedLike public ceiling;
     PileLike public pile;
     TokenLike public currency;
@@ -71,7 +71,7 @@ contract Shelf is Auth, TitleOwned, Math {
     mapping(uint256 => Loan) public shelf;
     mapping(bytes32 => uint256) public nftlookup;
 
-    // Events
+    /// Events
     event Close(uint256 indexed loan);
     event Issue(address indexed registry_, uint256 indexed token_);
     event Borrow(uint256 indexed loan, uint256 currencyAmount);
@@ -92,7 +92,9 @@ contract Shelf is Auth, TitleOwned, Math {
         emit Rely(msg.sender);
     }
 
-    // sets the dependency to another contract
+    /// @notice sets the dependency to another contract
+    /// @param contractName name of the contract
+    /// @param addr contract address
     function depend(bytes32 contractName, address addr) external auth {
         if (contractName == "token") {
             currency = TokenLike(addr);
@@ -115,26 +117,34 @@ contract Shelf is Auth, TitleOwned, Math {
         }
         emit Depend(contractName, addr);
     }
-
-    function token(uint256 loan) public view returns (address registry, uint256 nft) {
+    /// @notice returns the registry address and tokenId for a loan
+    /// @param loan the id of a loan
+    /// @return registry the address of the registry
+    /// @return tokenId the tokenId of the nft
+    function token(uint256 loan) public view returns (address registry, uint256 tokenId) {
         return (shelf[loan].registry, shelf[loan].tokenId);
     }
 
-    // issues a new loan in Tinlake - it requires the ownership of an nft
-    // first step in the loan process - everyone could add an nft
-    function issue(address registry_, uint256 token_) external returns (uint256) {
-        require(NFTLike(registry_).ownerOf(token_) == msg.sender, "nft-not-owned");
-        bytes32 nft = keccak256(abi.encodePacked(registry_, token_));
+    /// @notice issues a new loan in Tinlake - it requires the ownership of an nft
+    /// first step in the loan process - everyone could add an nft
+    /// @param registry the address of the registry
+    /// @param tokenId the tokenId of the nft
+    /// @return loan the id of the loan
+    function issue(address registry, uint256 tokenId) external returns (uint256 loan) {
+        require(NFTLike(registry).ownerOf(tokenId) == msg.sender, "nft-not-owned");
+        bytes32 nft = keccak256(abi.encodePacked(registry, tokenId));
         require(nftlookup[nft] == 0, "nft-in-use");
-        uint256 loan = title.issue(msg.sender);
+        loan = title.issue(msg.sender);
         nftlookup[nft] = loan;
-        shelf[loan].registry = registry_;
-        shelf[loan].tokenId = token_;
+        shelf[loan].registry = registry;
+        shelf[loan].tokenId = tokenId;
 
-        emit Issue(registry_, token_);
+        emit Issue(registry, tokenId);
         return loan;
     }
 
+    /// @notice closes a loan after the nft has been returned
+    /// @param loan the id of the loan
     function close(uint256 loan) external {
         require(!nftLocked(loan), "nft-locked");
         (address registry, uint256 tokenId) = token(loan);
@@ -149,11 +159,13 @@ contract Shelf is Auth, TitleOwned, Math {
         emit Close(loan);
     }
 
-    // starts the borrow process of a loan
-    // informs the system of the requested currencyAmount
-    // interest accumulation starts with this method
-    // the method can only be called if the nft is locked
-    // a max ceiling needs to be defined by an oracle
+    /// @notice starts the borrow process of a loan
+    /// informs the system of the requested currencyAmount
+    /// interest accumulation starts with this method
+    /// the method can only be called if the nft is locked
+    /// a max ceiling needs to be defined by an oracle
+    /// @param loan the id of the loan
+    /// @param currencyAmount the amount which should be borrowed
     function borrow(uint256 loan, uint256 currencyAmount) external owner(loan) {
         require(nftLocked(loan), "nft-not-locked");
 
@@ -179,7 +191,10 @@ contract Shelf is Auth, TitleOwned, Math {
         emit Borrow(loan, currencyAmount);
     }
 
-    // withdraw transfers the currency to the borrower account
+    /// @notice withdraw transfers the acutal currency to the borrower account
+    /// @param loan the id of the loan
+    /// @param currencyAmount the amount which should be withdrawn
+    /// @param usr the address of the receiver
     function withdraw(uint256 loan, uint256 currencyAmount, address usr) external owner(loan) {
         require(nftLocked(loan), "nft-not-locked");
         require(currencyAmount <= balances[loan], "withdraw-amount-too-high");
@@ -190,7 +205,9 @@ contract Shelf is Auth, TitleOwned, Math {
         emit Withdraw(loan, currencyAmount, usr);
     }
 
-    // repays the entire or partial debt of a loan
+    ///  @notice repays the entire or partial debt of a loan
+    ///  @param loan the id of the loan
+    ///  @param currencyAmount the amount which should be repaid
     function repay(uint256 loan, uint256 currencyAmount) external owner(loan) {
         require(nftLocked(loan), "nft-not-locked");
         require(balances[loan] == 0, "withdraw-required-before-repay");
@@ -217,8 +234,11 @@ contract Shelf is Auth, TitleOwned, Math {
         emit Repay(loan, currencyAmount);
     }
 
-    // a collector can recover defaulted loans
-    // it is not required to recover the entire loan debt
+    /// @notice a collector can recover defaulted loans
+    /// it is not required to recover the entire loan debt
+    /// @param loan the id of the loan
+    /// @param usr the address of the collector which pays the debt
+    /// @param currencyAmount the amount which should be recovered
     function recover(uint256 loan, address usr, uint256 currencyAmount) external auth {
         pile.accrue(loan);
 
@@ -236,25 +256,9 @@ contract Shelf is Auth, TitleOwned, Math {
         emit Recover(loan, usr, currencyAmount);
     }
 
-    function _repay(uint256 loan, address usr, uint256 currencyAmount) internal {
-        pile.accrue(loan);
-        uint256 loanDebt = pile.debt(loan);
-
-        // only repay max loan debt
-        if (currencyAmount > loanDebt) {
-            currencyAmount = loanDebt;
-        }
-        require(currency.transferFrom(usr, address(this), currencyAmount), "currency-transfer-failed");
-        ceiling.repay(loan, currencyAmount);
-        pile.decDebt(loan, currencyAmount);
-
-        reserve.deposit(currencyAmount);
-        // reBalance lender interest bearing amount based on new NAV
-        assessor.reBalance();
-    }
-
-    // locks an nft in the shelf
-    // requires an issued loan
+    /// @notice locks an nft in the shelf
+    /// requires an issued loan
+    /// @param loan the id of the loan
     function lock(uint256 loan) external owner(loan) {
         if (address(subscriber) != address(0)) {
             subscriber.lockEvent(loan);
@@ -263,8 +267,9 @@ contract Shelf is Auth, TitleOwned, Math {
         emit Lock(loan);
     }
 
-    // unlocks an nft in the shelf
-    // requires zero debt or 100% write off
+    /// @notice unlocks an nft in the shelf
+    /// requires zero debt or 100% write off
+    /// @param loan the id of the loan
     function unlock(uint256 loan) external owner(loan) {
         // loans can be unlocked and closed when the debt is 0, or the loan is written off 100%
         uint256 debt_ = pile.debt(loan);
@@ -279,18 +284,23 @@ contract Shelf is Auth, TitleOwned, Math {
 
         emit Unlock(loan);
     }
-
+    /// @notice returns the information if an nft has been locked
+    /// @param loan the id of the loan
     function nftLocked(uint256 loan) public view returns (bool) {
         return NFTLike(shelf[loan].registry).ownerOf(shelf[loan].tokenId) == address(this);
     }
 
-    // a loan can be claimed by a collector if the loan debt is above the loan threshold
-    // transfers the nft to the collector
+    /// @notice a loan can be claimed by a collector if the loan debt is above the loan threshold
+    /// transfers the nft to the collector
+    /// @param loan the id of the loan
+    /// @param usr the address of the collector
     function claim(uint256 loan, address usr) public auth {
         NFTLike(shelf[loan].registry).transferFrom(address(this), usr, shelf[loan].tokenId);
         emit Claim(loan, usr);
     }
 
+    /// @notice resets the balance of a loan
+    /// @param loan the id of the loan
     function _resetLoanBalance(uint256 loan) internal {
         uint256 loanBalance = balances[loan];
         if (loanBalance > 0) {
@@ -299,8 +309,9 @@ contract Shelf is Auth, TitleOwned, Math {
         }
     }
 
-    // returns the total number of loans including closed loans
-    function loanCount() public view returns (uint256) {
+    /// @notice returns the total number of loans including closed loans
+    /// @return totalNumber total number of loans
+    function loanCount() public view returns (uint256 totalNumber) {
         return title.count();
     }
 }

--- a/src/borrower/shelf.sol
+++ b/src/borrower/shelf.sol
@@ -121,6 +121,7 @@ contract Shelf is Auth, TitleOwned, Math {
     /// @param loan the id of a loan
     /// @return registry the address of the registry
     /// @return tokenId the tokenId of the nft
+
     function token(uint256 loan) public view returns (address registry, uint256 tokenId) {
         return (shelf[loan].registry, shelf[loan].tokenId);
     }
@@ -286,6 +287,7 @@ contract Shelf is Auth, TitleOwned, Math {
     }
     /// @notice returns the information if an nft has been locked
     /// @param loan the id of the loan
+
     function nftLocked(uint256 loan) public view returns (bool) {
         return NFTLike(shelf[loan].registry).ownerOf(shelf[loan].tokenId) == address(this);
     }

--- a/src/borrower/wrappers/writeOffWrapper.sol
+++ b/src/borrower/wrappers/writeOffWrapper.sol
@@ -52,9 +52,9 @@ contract WriteOffWrapper is Auth, Discounting {
 
     /// @notice writes of an overdue loan
     /// @param loan the loan id
-    /// @param feed address of the feed
-    function writeOff(uint256 loan, address feed) public auth {
-        FeedLike feed = FeedLike(feed);
+    /// @param nftFeed address of the feed
+    function writeOff(uint256 loan, address nftFeed) public auth {
+        FeedLike feed = FeedLike(nftFeed);
         PileLike pile = PileLike(feed.pile());
         require(writeOffRates[address(pile)] != 0, "WriteOffWrapper/pile-has-no-write-off-group");
         ShelfLike shelf = ShelfLike(feed.shelf());

--- a/src/borrower/wrappers/writeOffWrapper.sol
+++ b/src/borrower/wrappers/writeOffWrapper.sol
@@ -26,6 +26,8 @@ interface FeedLike {
     function maturityDate(bytes32 nft_) external view returns (uint256);
 }
 
+/// @notice WriteOff contract can move overdue loans into a write off group
+/// The wrapper contract manages multiple different pools
 contract WriteOffWrapper is Auth, Discounting {
     mapping(address => uint256) public writeOffRates;
 
@@ -48,19 +50,22 @@ contract WriteOffWrapper is Auth, Discounting {
         writeOffRates[address(0x4b0f712Aa9F91359f48D8628De8483B04530751a)] = 1001; // Peoples 1
     }
 
-    function writeOff(uint256 _loanID, address _feed) public auth {
-        FeedLike feed = FeedLike(_feed);
+    /// @notice writes of an overdue loan
+    /// @param loan the loan id
+    /// @param feed address of the feed
+    function writeOff(uint256 loan, address feed) public auth {
+        FeedLike feed = FeedLike(feed);
         PileLike pile = PileLike(feed.pile());
         require(writeOffRates[address(pile)] != 0, "WriteOffWrapper/pile-has-no-write-off-group");
         ShelfLike shelf = ShelfLike(feed.shelf());
-        require(shelf.shelf(_loanID).tokenId != 0, "WriteOffWrapper/loan-does-not-exist");
+        require(shelf.shelf(loan).tokenId != 0, "WriteOffWrapper/loan-does-not-exist");
         uint256 nnow = uniqueDayTimestamp(block.timestamp);
-        bytes32 nftID = feed.nftID(_loanID);
+        bytes32 nftID = feed.nftID(loan);
         uint256 maturityDate = feed.maturityDate(nftID);
 
         require(maturityDate < nnow, "WriteOffWrapper/loan-not-overdue");
 
-        pile.changeRate(_loanID, writeOffRates[address(pile)]);
+        pile.changeRate(loan, writeOffRates[address(pile)]);
     }
 
     function file(bytes32 what, address addr, uint256 data) public auth {

--- a/src/borrower/wrappers/writeOffWrapper.sol
+++ b/src/borrower/wrappers/writeOffWrapper.sol
@@ -50,7 +50,7 @@ contract WriteOffWrapper is Auth, Discounting {
         writeOffRates[address(0x4b0f712Aa9F91359f48D8628De8483B04530751a)] = 1001; // Peoples 1
     }
 
-    /// @notice writes of an overdue loan
+    /// @notice writes off an overdue loan
     /// @param loan the loan id
     /// @param nftFeed address of the feed
     function writeOff(uint256 loan, address nftFeed) public auth {


### PR DESCRIPTION
I started to add `NatSpec` comments for the borrower contracts.
It is a commonly used standard nowadays for Solidity.

Writing those comments is surprisingly easy together with Github Copilot. 

For me, it is also an excellent way to refresh my understanding of the codebase again. 




