### PR TITLE
rpc-tests: deactivate clerk for basic tests

### DIFF
--- a/script/rpc-tests/rpc-tests.sol
+++ b/script/rpc-tests/rpc-tests.sol
@@ -36,6 +36,10 @@ interface TAuth {
     function wards(address) external returns (uint256);
 }
 
+interface MgrLike {
+    function urn() external returns (address);
+}
+
 contract TinlakeRPCTests is Test, Assertions {
     TinlakeRoot root;
     PoolAdmin poolAdmin;
@@ -54,6 +58,7 @@ contract TinlakeRPCTests is Test, Assertions {
     T_ERC20 seniorToken;
     Tranche seniorTranche;
     Tranche juniorTranche;
+    MgrLike mgr;
 
     function initRPC(address _root) public {
         root = TinlakeRoot(_root);
@@ -77,6 +82,7 @@ contract TinlakeRPCTests is Test, Assertions {
         seniorToken = T_ERC20(address(lenderDeployer.seniorToken()));
         currency = T_ERC20(address(Reserve(address(lenderDeployer.reserve())).currency()));
         registry = new Title("TEST", "TEST");
+        mgr = MgrLike(address(clerk.mgr()));
 
         // cheat: give testContract permissions on root contract by overriding storage
         // storage slot for permissions => keccak256(key, mapslot) (mapslot = 0)

--- a/script/run-rpc-tests.s.sol
+++ b/script/run-rpc-tests.s.sol
@@ -6,10 +6,6 @@ import "forge-std/Script.sol";
 
 import {TinlakeRPCTests} from "./rpc-tests/rpc-tests.sol";
 
-interface DependLike {
-    function depend(bytes32, address) external;
-}
-
 contract RunRPCTests is Script, TinlakeRPCTests {
     function setUp() public {}
 

--- a/script/run-rpc-tests.s.sol
+++ b/script/run-rpc-tests.s.sol
@@ -6,16 +6,46 @@ import "forge-std/Script.sol";
 
 import {TinlakeRPCTests} from "./rpc-tests/rpc-tests.sol";
 
+interface DependLike {
+    function depend(bytes32, address) external;
+}
+
 contract RunRPCTests is Script, TinlakeRPCTests {
     function setUp() public {}
 
+    function _isMakerLive() internal returns (bool) {
+        return mgr.urn() != address(0) && clerk.activated();
+    }
+
+    function _deactivateClerk() internal {
+        if (address(assessor.lending()) != address(0)) {
+            console.log("PreRPC Test: remove clerk dependency from assessor");
+            root.relyContract(address(assessor), address(this));
+            assessor.depend("lending", address(0));
+        }
+
+        if (address(reserve.lending()) != address(0)) {
+            console.log("PreRPC Test: remove clerk dependency from reserve");
+            root.relyContract(address(reserve), address(this));
+            reserve.depend("lending", address(0));
+        }
+    }
+
     function run() public {
         initRPC(vm.envAddress("ROOT_CONTRACT"));
-
         if (vm.envBool("MAKER_RPC_TESTS") == true) {
-            runLoanCycleWithMaker();
+            console.log("Running: Maker RPC tests");
+            if (_isMakerLive()) {
+                runLoanCycleWithMaker();
+            } else {
+                revert("Maker is not live");
+            }
         } else {
+            // deactivate clerk to run without maker
+            console.log("Running: Basic RPC tests");
+            _deactivateClerk();
             runLoanCycleWithoutMaker();
         }
+        console.log("RPC tests passed");
     }
 }


### PR DESCRIPTION
 **Basic RPC Tests**
 - remove `clerk` dependency from pool for basic rpc-test if needed
     - optional removal from assessor
     - optional removal from reserve
     
**MKR RPC Tests**
- revert immediately if MKR is not live
   - for example MKR spell not executed