### PR TITLE
Change write-off wrapper to accept root as parameter

### DIFF
--- a/src/borrower/wrappers/writeOffWrapper.sol
+++ b/src/borrower/wrappers/writeOffWrapper.sol
@@ -27,7 +27,6 @@ interface FeedLike {
 }
 
 interface RootLike {
-    function relyContract(address, address) external;
     function borrowerDeployer() external view returns (address);
 }
 
@@ -63,7 +62,7 @@ contract WriteOffWrapper is Auth, Discounting {
 
     /// @notice writes off an overdue loan
     /// @param root the address of the root contract
-    function writeOff(uint256 loan, address root) public auth {
+    function writeOff(address root, uint256 loan) public auth {
         BorrowerDeployerLike deployer = BorrowerDeployerLike(RootLike(root).borrowerDeployer());
         FeedLike feed = FeedLike(deployer.feed());
         PileLike pile = PileLike(deployer.pile());

--- a/src/borrower/wrappers/writeOffWrapper.sol
+++ b/src/borrower/wrappers/writeOffWrapper.sol
@@ -63,7 +63,7 @@ contract WriteOffWrapper is Auth, Discounting {
 
     /// @notice writes off an overdue loan
     /// @param root the address of the root contract
-    function writeOff(uint256 loan, address root) public {
+    function writeOff(uint256 loan, address root) public auth {
         BorrowerDeployerLike deployer = BorrowerDeployerLike(RootLike(root).borrowerDeployer());
         FeedLike feed = FeedLike(deployer.feed());
         PileLike pile = PileLike(deployer.pile());

--- a/src/borrower/wrappers/writeOffWrapper.sol
+++ b/src/borrower/wrappers/writeOffWrapper.sol
@@ -26,6 +26,17 @@ interface FeedLike {
     function maturityDate(bytes32 nft_) external view returns (uint256);
 }
 
+interface RootLike {
+    function relyContract(address, address) external;
+    function borrowerDeployer() external view returns (address);
+}
+
+interface BorrowerDeployerLike {
+    function pile() external view returns (address);
+    function shelf() external view returns (address);
+    function feed() external view returns (address);
+}
+
 /// @notice WriteOff contract can move overdue loans into a write off group
 /// The wrapper contract manages multiple different pools
 contract WriteOffWrapper is Auth, Discounting {
@@ -41,7 +52,7 @@ contract WriteOffWrapper is Auth, Discounting {
         writeOffRates[address(0x11C14AAa42e361Cf3500C9C46f34171856e3f657)] = 1000; // Fortunafi 1
         writeOffRates[address(0xE7876f282bdF0f62e5fdb2C63b8b89c10538dF32)] = 1000; // Harbor Trade 2
         writeOffRates[address(0x3eC5c16E7f2C6A80E31997C68D8Fa6ACe089807f)] = 1000; // New Silver 2
-        writeOffRates[address(0xe17F3c35C18b2Af84ceE2eDed673c6A08A671695)] = 1001; // Branch Series 3
+        writeOffRates[address(0xe17F3c35C18b2Af84ceE2eDed673c6A08A671695)] = 1000; // Branch Series 3
         writeOffRates[address(0x99D0333f97432fdEfA25B7634520d505e58B131B)] = 1000; // FactorChain 1
         writeOffRates[address(0x37c8B836eA1b89b7cC4cFdDed4C4fbC454CcC679)] = 1000; // Paperchain 3
         writeOffRates[address(0xB7d1DE24c0243e6A3eC4De9fAB2B19AB46Fa941F)] = 1001; // UP Series 1
@@ -51,15 +62,13 @@ contract WriteOffWrapper is Auth, Discounting {
     }
 
     /// @notice writes off an overdue loan
-    /// @param loan the loan id
-    /// @param navFeed address of the feed
-    /// @param pile address of the pile
-    /// @param shelf address of the shelf
-    function writeOff(uint256 loan, address navFeed, address pile, address shelf) public auth {
-        FeedLike feed = FeedLike(navFeed);
-        PileLike pile = PileLike(pile);
+    /// @param root the address of the root contract
+    function writeOff(uint256 loan, address root) public {
+        BorrowerDeployerLike deployer = BorrowerDeployerLike(RootLike(root).borrowerDeployer());
+        FeedLike feed = FeedLike(deployer.feed());
+        PileLike pile = PileLike(deployer.pile());
         require(writeOffRates[address(pile)] != 0, "WriteOffWrapper/pile-has-no-write-off-group");
-        ShelfLike shelf = ShelfLike(shelf);
+        ShelfLike shelf = ShelfLike(deployer.shelf());
         require(shelf.shelf(loan).tokenId != 0, "WriteOffWrapper/loan-does-not-exist");
         uint256 nnow = uniqueDayTimestamp(block.timestamp);
         bytes32 nftID = feed.nftID(loan);

--- a/src/borrower/wrappers/writeOffWrapper.sol
+++ b/src/borrower/wrappers/writeOffWrapper.sol
@@ -52,12 +52,14 @@ contract WriteOffWrapper is Auth, Discounting {
 
     /// @notice writes off an overdue loan
     /// @param loan the loan id
-    /// @param nftFeed address of the feed
-    function writeOff(uint256 loan, address nftFeed) public auth {
-        FeedLike feed = FeedLike(nftFeed);
-        PileLike pile = PileLike(feed.pile());
+    /// @param navFeed address of the feed
+    /// @param pile address of the pile
+    /// @param shelf address of the shelf
+    function writeOff(uint256 loan, address navFeed, address pile, address shelf) public auth {
+        FeedLike feed = FeedLike(navFeed);
+        PileLike pile = PileLike(pile);
         require(writeOffRates[address(pile)] != 0, "WriteOffWrapper/pile-has-no-write-off-group");
-        ShelfLike shelf = ShelfLike(feed.shelf());
+        ShelfLike shelf = ShelfLike(shelf);
         require(shelf.shelf(loan).tokenId != 0, "WriteOffWrapper/loan-does-not-exist");
         uint256 nnow = uniqueDayTimestamp(block.timestamp);
         bytes32 nftID = feed.nftID(loan);

--- a/test/borrower/mock/deployer.sol
+++ b/test/borrower/mock/deployer.sol
@@ -4,7 +4,6 @@ pragma solidity >=0.7.6;
 import "../../mock/mock.sol";
 
 contract BorrowerDeployerMock is Mock {
-
     function shelf() public view returns (address) {
         return values_address_return["shelf"];
     }

--- a/test/borrower/mock/deployer.sol
+++ b/test/borrower/mock/deployer.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity >=0.7.6;
+
+import "../../mock/mock.sol";
+
+contract BorrowerDeployerMock is Mock {
+
+    function shelf() public view returns (address) {
+        return values_address_return["shelf"];
+    }
+
+    function pile() public view returns (address) {
+        return values_address_return["pile"];
+    }
+
+    function feed() public view returns (address) {
+        return values_address_return["feed"];
+    }
+}

--- a/test/borrower/wrappers/writeOffWrapper.t.sol
+++ b/test/borrower/wrappers/writeOffWrapper.t.sol
@@ -41,10 +41,8 @@ contract WriteOffTest is Test, Discounting {
         navFeed.setBytes32Return("nftID", "1");
         shelf.setReturn("shelf", address(1));
         shelf.setReturn("shelf", 1);
-        navFeed.setReturn("pile", address(pile));
-        navFeed.setReturn("shelf", address(shelf));
 
-        writeOffWrapper.writeOff(1, address(navFeed));
+        writeOffWrapper.writeOff(1, address(navFeed), address(pile), address(shelf));
         assertEq(pile.calls("changeRate"), 1);
     }
 
@@ -54,10 +52,8 @@ contract WriteOffTest is Test, Discounting {
         navFeed.setBytes32Return("nftID", "1");
         shelf.setReturn("shelf", address(1));
         shelf.setReturn("shelf", 1);
-        navFeed.setReturn("pile", address(pile));
-        navFeed.setReturn("shelf", address(shelf));
 
-        writeOffWrapper.writeOff(1, address(navFeed));
+        writeOffWrapper.writeOff(1, address(navFeed), address(pile), address(shelf));
         assertEq(pile.calls("changeRate"), 1);
     }
 
@@ -65,16 +61,14 @@ contract WriteOffTest is Test, Discounting {
         // set mock data
         navFeed.setReturn("maturityDate", block.timestamp - 60 * 60 * 24);
         navFeed.setBytes32Return("nftID", "1");
-        navFeed.setReturn("pile", address(pile));
-        navFeed.setReturn("shelf", address(shelf));
 
-        writeOffWrapper.writeOff(1, address(navFeed));
+        writeOffWrapper.writeOff(1, address(navFeed), address(pile), address(shelf));
         assertEq(pile.calls("changeRate"), 1);
     }
 
     function testFailWriteOffLoanNotOverDue() public {
         navFeed.setReturn("maturityDate", block.timestamp + 60 * 60 * 24);
         navFeed.setBytes32Return("nftID", "1");
-        writeOffWrapper.writeOff(1, address(navFeed));
+        writeOffWrapper.writeOff(1, address(navFeed), address(pile), address(shelf));
     }
 }

--- a/test/borrower/wrappers/writeOffWrapper.t.sol
+++ b/test/borrower/wrappers/writeOffWrapper.t.sol
@@ -52,7 +52,7 @@ contract WriteOffTest is Test, Discounting {
         shelf.setReturn("shelf", address(1));
         shelf.setReturn("shelf", 1);
 
-        writeOffWrapper.writeOff(1, address(root));
+        writeOffWrapper.writeOff(address(root), 1);
         assertEq(pile.calls("changeRate"), 1);
     }
 
@@ -63,7 +63,7 @@ contract WriteOffTest is Test, Discounting {
         shelf.setReturn("shelf", address(1));
         shelf.setReturn("shelf", 1);
 
-        writeOffWrapper.writeOff(1, address(root));
+        writeOffWrapper.writeOff(address(root), 1);
         assertEq(pile.calls("changeRate"), 1);
     }
 
@@ -72,13 +72,13 @@ contract WriteOffTest is Test, Discounting {
         navFeed.setReturn("maturityDate", block.timestamp - 60 * 60 * 24);
         navFeed.setBytes32Return("nftID", "1");
 
-        writeOffWrapper.writeOff(1, address(root));
+        writeOffWrapper.writeOff(address(root), 1);
         assertEq(pile.calls("changeRate"), 1);
     }
 
     function testFailWriteOffLoanNotOverDue() public {
         navFeed.setReturn("maturityDate", block.timestamp + 60 * 60 * 24);
         navFeed.setBytes32Return("nftID", "1");
-        writeOffWrapper.writeOff(1, address(root));
+        writeOffWrapper.writeOff(address(root), 1);
     }
 }

--- a/test/borrower/wrappers/writeOffWrapper.t.sol
+++ b/test/borrower/wrappers/writeOffWrapper.t.sol
@@ -4,6 +4,8 @@ pragma solidity >=0.7.6;
 import "forge-std/Test.sol";
 import "src/borrower/wrappers/writeOffWrapper.sol";
 import {Discounting} from "src/borrower/feed/discounting.sol";
+import "../../mock/root.sol";
+import "../mock/deployer.sol";
 import "../mock/pile.sol";
 import "../mock/feed.sol";
 import "../mock/shelf.sol";
@@ -13,12 +15,20 @@ contract WriteOffTest is Test, Discounting {
     PileMock pile;
     NAVFeedMock navFeed;
     ShelfMock shelf;
+    BorrowerDeployerMock deployer;
+    RootMock root;
 
     function setUp() public {
         writeOffWrapper = new WriteOffWrapper();
         pile = new PileMock();
         navFeed = new NAVFeedMock();
         shelf = new ShelfMock();
+        deployer = new BorrowerDeployerMock();
+        deployer.setReturn("pile", address(pile));
+        deployer.setReturn("feed", address(navFeed));
+        deployer.setReturn("shelf", address(shelf));
+        root = new RootMock();
+        root.setReturn("borrowerDeployer", address(deployer));
     }
 
     function testFile() public {
@@ -42,7 +52,7 @@ contract WriteOffTest is Test, Discounting {
         shelf.setReturn("shelf", address(1));
         shelf.setReturn("shelf", 1);
 
-        writeOffWrapper.writeOff(1, address(navFeed), address(pile), address(shelf));
+        writeOffWrapper.writeOff(1, address(root));
         assertEq(pile.calls("changeRate"), 1);
     }
 
@@ -53,7 +63,7 @@ contract WriteOffTest is Test, Discounting {
         shelf.setReturn("shelf", address(1));
         shelf.setReturn("shelf", 1);
 
-        writeOffWrapper.writeOff(1, address(navFeed), address(pile), address(shelf));
+        writeOffWrapper.writeOff(1, address(root));
         assertEq(pile.calls("changeRate"), 1);
     }
 
@@ -62,13 +72,13 @@ contract WriteOffTest is Test, Discounting {
         navFeed.setReturn("maturityDate", block.timestamp - 60 * 60 * 24);
         navFeed.setBytes32Return("nftID", "1");
 
-        writeOffWrapper.writeOff(1, address(navFeed), address(pile), address(shelf));
+        writeOffWrapper.writeOff(1, address(root));
         assertEq(pile.calls("changeRate"), 1);
     }
 
     function testFailWriteOffLoanNotOverDue() public {
         navFeed.setReturn("maturityDate", block.timestamp + 60 * 60 * 24);
         navFeed.setBytes32Return("nftID", "1");
-        writeOffWrapper.writeOff(1, address(navFeed), address(pile), address(shelf));
+        writeOffWrapper.writeOff(1, address(root));
     }
 }

--- a/test/mock/root.sol
+++ b/test/mock/root.sol
@@ -4,7 +4,6 @@ pragma solidity >=0.7.6;
 import "./mock.sol";
 
 contract RootMock is Mock {
-
     function borrowerDeployer() public view returns (address) {
         return values_address_return["borrowerDeployer"];
     }

--- a/test/mock/root.sol
+++ b/test/mock/root.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity >=0.7.6;
+
+import "./mock.sol";
+
+contract RootMock is Mock {
+
+    function borrowerDeployer() public view returns (address) {
+        return values_address_return["borrowerDeployer"];
+    }
+}


### PR DESCRIPTION
The current writeoff wrapper assumes the NAV feed has a public shelf and pile variable, but on the feeds this will be used on, those variables don't exist. This PR changes the writeoff wrapper to take those addresses as arguments instead